### PR TITLE
Use static_url and route_url

### DIFF
--- a/development.ini.in
+++ b/development.ini.in
@@ -29,12 +29,12 @@ default_max_age = 864000
 pyramid_closure.roots =
     ${closure_library_path}/closure/goog
 pyramid_closure.roots_with_prefix =
-    ../../../proj/js %(here)s/geoportailv3/static/js
-    ../../../node_modules/openlayers %(here)s/node_modules/openlayers
-    ../../../node_modules/ngeo %(here)s/node_modules/ngeo
+    ../../../../../../../../../proj/js %(here)s/geoportailv3/static/js
+    ../../../../../../../../../node_modules/openlayers %(here)s/node_modules/openlayers
+    ../../../../../../../../../node_modules/ngeo %(here)s/node_modules/ngeo
 
 # used for the "node_modules" and "closure" static views
-node_modules_path = %(here)s/node_modules/
+node_modules_path = %(here)s/node_modules
 closure_library_path = ${closure_library_path}
 
 pyramid.includes =

--- a/geoportailv3/templates/ngeo.html
+++ b/geoportailv3/templates/ngeo.html
@@ -1,3 +1,8 @@
+<%
+    settings = request.registry.settings
+    node_modules_path = settings.get('node_modules_path')
+    closure_library_path = settings.get('closure_library_path')
+%>\
 <!DOCTYPE html>
 <html lang={{lang}} ng-app="app" ng-controller="MainController">
   <head>
@@ -7,9 +12,9 @@
           content="initial-scale=1.0, user-scalable=no, width=device-width">
     <meta name="apple-mobile-web-app-capable" content="yes">
 % if debug:
-    <link rel="stylesheet" href="/proj/build/build.css" type="text/css">
+    <link rel="stylesheet" href="${request.static_url('geoportailv3:static/build/build.css')}" type="text/css">
 % else:
-    <link rel="stylesheet" href="/proj/build/build.min.css" type="text/css">
+    <link rel="stylesheet" href="${request.static_url('geoportailv3:static/build/build.min.css')}" type="text/css">
 % endif
   </head>
   <body>
@@ -17,20 +22,20 @@
     <div id="map" ngeo-map></div>
     <button class="btn btn-default">a button</button>
 % if debug:
-    <script src="/node_modules/angular/angular.js"></script>
-    <script src="/node_modules/angular-gettext/dist/angular-gettext.js"></script>
-    <script src="/closure/closure/goog/base.js"></script>
-    <script src="${request.route_path('deps.js')}"></script>
-    <script src="/proj/js/main.js"></script>
+    <script src="${request.static_url('%s/angular/angular.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/closure/goog/base.js' % closure_library_path)}"></script>
+    <script src="${request.route_url('deps.js')}"></script>
+    <script src="${request.static_url('geoportailv3:static/js/main.js')}"></script>
 % else:
-    <script src="/node_modules/angular/angular.min.js"></script>
-    <script src="/node_modules/angular-gettext/dist/angular-gettext.min.js"></script>
-    <script src="/proj/build/build.js"></script>
+    <script src="${request.static_url('%s/angular/angular.min.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.min.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('geoportailv3:static/build/build.js')}"></script>
 % endif
     <script>
       (function() {
          var appModule = angular.module('app');
-         appModule.constant('langUrlTemplate', '/proj/build/locale/__lang__/geoportailv3.json');
+         appModule.constant('langUrlTemplate', '${request.static_url('geoportailv3:static/build/locale/__lang__/geoportailv3.json')}');
        })();
     </script>
   </body>

--- a/production.ini.in
+++ b/production.ini.in
@@ -29,12 +29,12 @@ default_max_age = 864000
 pyramid_closure.roots =
     ${closure_library_path}/closure/goog
 pyramid_closure.roots_with_prefix =
-    ../../../proj/js %(here)s/geoportailv3/static/js
-    ../../../node_modules/openlayers %(here)s/node_modules/openlayers
-    ../../../node_modules/ngeo %(here)s/node_modules/ngeo
+    ../../../../../../../../../proj/js %(here)s/geoportailv3/static/js
+    ../../../../../../../../../node_modules/openlayers %(here)s/node_modules/openlayers
+    ../../../../../../../../../node_modules/ngeo %(here)s/node_modules/ngeo
 
 # used for the "node_modules" and "closure" static views
-node_modules_path = %(here)s/node_modules/
+node_modules_path = %(here)s/node_modules
 closure_library_path = ${closure_library_path}
 
 # used for the "node_modules" and "closure" static views


### PR DESCRIPTION
This PR makes uses of `request.static_url` and `request.route_url` in the `ngeo.html` Mako template. In this way we create correct URLs when using `pserve` as well as when using Apache `mod_wsgi`. It also makes it possible to use [Chache Busting](http://docs.pylonsproject.org/projects/pyramid/en/master/narr/assets.html#cache-busting) and  ["multi-domain" URLs](https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/lib/__init__.py#L83-L105).

@fredj, I plan to make a PR to `pyramid_closure` for that as well. Does it makes sense to you?
