### PR TITLE
Add an update-node-modules Makefile target

### DIFF
--- a/CONST_Makefile
+++ b/CONST_Makefile
@@ -17,19 +17,20 @@ help:
 	@echo
 	@echo "Main targets:"
 	@echo
-	@echo "- build              Build and configure the project"
-	@echo "- check              Perform a number of checks on the code"
-	@echo "- serve              Run the development server (pserve)"
-	@echo "- clean              Remove generated files"
-	@echo "- cleanall           Remove all the build artefacts"
+	@echo "- build                Build and configure the project"
+	@echo "- check                Perform a number of checks on the code"
+	@echo "- serve                Run the development server (pserve)"
+	@echo "- clean                Remove generated files"
+	@echo "- cleanall             Remove all the build artefacts"
 	@echo
 	@echo "Secondary targets:"
 	@echo
-	@echo "- build-web          Build the javascript and the css"
-	@echo "- build-server       Build the files required by the server"
-	@echo "- compile-catalog    Compile the translation catalog"
-	@echo "- flake8             Run flake8 checker on the Python code"
-	@echo "- lint               Check the JavaScript code with linters"
+	@echo "- build-web            Build the javascript and the css"
+	@echo "- build-server         Build the files required by the server"
+	@echo "- compile-catalog      Compile the translation catalog"
+	@echo "- flake8               Run flake8 checker on the Python code"
+	@echo "- lint                 Check the JavaScript code with linters"
+	@echo "- update-node-modules  Update node modules (using --force)"
 	@echo
 
 .PHONY: build
@@ -73,6 +74,10 @@ lint: .build/venv/bin/gjslint .build/node_modules.timestamp .build/gjslint.times
 .PHONY: serve
 serve: build development.ini
 	.build/venv/bin/pserve --reload --monitor-restart development.ini
+
+.PHONY: update-node-modules
+update-node-modules:
+	npm install --force
 
 $(TEMPLATE_FILES:.in=): $(TEMPLATE_FILES) .build/venv/bin/c2c-template ${VARS_FILES}
 ifeq ($(origin VARS_FILE), undefined)


### PR DESCRIPTION
Currently to update ngeo (or openlayers) to the latest "master" one must manually remove the "node_modules/ngeo" directory first (`rm -rf node_modules/ngeo`). This PR adds an "update-node-modules" target that does `npm install --force`. This forces the re-installation of all the node dependencies, which will effectively download the latest "master" for ngeo.

Please review.
