### PR TITLE
Annotate MainController with @export

### DIFF
--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -17,6 +17,7 @@ goog.require('ol.tilegrid.WMTS');
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {string} langUrlTemplate Language URL template.
  * @constructor
+ * @export
  * @ngInject
  */
 app.MainController = function($scope, gettextCatalog, langUrlTemplate) {


### PR DESCRIPTION
As explained in https://github.com/camptocamp/ngeo/blob/master/docs/guidelines.md#use-export-for-controllers we need to annotate the `MainController` with `@export`.
