### PR TITLE
Load ngeo's watchwatchers script in dev mode

### DIFF
--- a/geoportailv3/templates/ngeo.html
+++ b/geoportailv3/templates/ngeo.html
@@ -89,6 +89,7 @@
     <script src="${request.static_url('%s/closure/goog/base.js' % closure_library_path)}"></script>
     <script src="${request.route_url('deps.js')}"></script>
     <script src="${request.static_url('geoportailv3:static/js/main.js')}"></script>
+    <script src="${request.static_url('%s/ngeo/utils/watchwatchers.js' % node_modules_path)}"></script>
 % else:
     <script src="${request.static_url('%s/angular/angular.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.min.js' % node_modules_path)}"></script>


### PR DESCRIPTION
One can then use `countWatchers()` in the console to display the current number of Angular watchers.
