### PR TITLE
Remove exports from build.js

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,5 +1,5 @@
 {
-  "exports": ["*"],
+  "exports": [],
   "src": [
     "node_modules/openlayers/src/**/*.js",
     "node_modules/openlayers/build/ol.ext/**/*.js",
@@ -66,9 +66,11 @@
       "typeInvalidation",
       "undefinedNames",
       "undefinedVars",
-      "unknownDefines",
       "uselessCode",
       "visibility"
+    ],
+    "jscomp_off": [
+      "unknownDefines"
     ],
     "extra_annotation_name": [
       "api", "observable"


### PR DESCRIPTION
With this the size of build.js goes from 398K to 107K.

Note: it is necessary to set "unknownDefines" to "off" not to get the following error:

```
node tasks/build.js build.json geoportailv3/static/build/build.js
info geoportailv3 Parsing dependencies
info geoportailv3 Compiling 376 sources
ERR! compile ERROR - unknown @define variable goog.json.USE_NATIVE_JSON
ERR! compile 
ERR! compile 1 error(s), 0 warning(s), 
ERR! compile 97.7% typed
ERR! compile 
ERR! Process exited with non-zero status, see log for more detail: 1 
make: *** [geoportailv3/static/build/build.js] Error 1
```