### PR TITLE
More specific pyramid_closure root for ngeo

### DIFF
--- a/CONST_vars.yaml
+++ b/CONST_vars.yaml
@@ -71,7 +71,7 @@ vars:
     pyramid_closure.roots_with_prefix: '
         ../../../../../../../../../proj/js {directory}/geoportailv3/static/js
         ../../../../../../../../../node_modules/openlayers {directory}/node_modules/openlayers
-        ../../../../../../../../../node_modules/ngeo {directory}/node_modules/ngeo'
+        ../../../../../../../../../node_modules/ngeo/src {directory}/node_modules/ngeo/src'
 
     # used for the "node_modules" and "closure" static views
     node_modules_path: '{directory}/node_modules'


### PR DESCRIPTION
This PR uses a more specific pyramid_closure `root` for ngeo. This is to avoid problems when using a built ngeo source tree (with `ngeo.js` and `ngeo-debug.js` in `dist/`).