### PR TITLE
Prevent injected service from being renamed

### DIFF
--- a/geoportailv3/static/js/layermanager/layermanagerdirective.js
+++ b/geoportailv3/static/js/layermanager/layermanagerdirective.js
@@ -6,6 +6,7 @@ goog.require('app');
 /**
  * @param {string} appLayermanagerTemplateUrl Url to layermanager template
  * @return {angular.Directive} The Directive Definition Object.
+ * @ngInject
  */
 app.layermanagerDirective = function(appLayermanagerTemplateUrl) {
   return {


### PR DESCRIPTION
Fixing the issue with layer manager not showing on built version.
Please review.