### PR TITLE
Opacity and visibility interaction

### DIFF
--- a/geoportailv3/static/js/layermanager/layermanager.html
+++ b/geoportailv3/static/js/layermanager/layermanager.html
@@ -7,7 +7,7 @@
       <span class="expanded fa fa-remove"></span>
     </a>
     <div id="layermanager-item-{{$index}}" class="collapse">
-      <a href ng-click="layer.visible = !layer.visible"><span class="fa" ng-class="{'fa-eye': layer.visible, 'fa-eye-slash': !layer.visible}" ></span></a>
+      <a href ng-click="ctrl.changeVisibility(layer)"><span class="fa" ng-class="(layer.opacity > 0) ? 'fa-eye': 'fa-eye-slash'" ></span></a>
       <input class="opacity" type="range" min="0" max="1" step="0.05" ng-model="layer.opacity" />
       <a class="delete" ng-click="ctrl.removeLayer(layer);"><span class="fa fa-trash-o"></span></a>
     </div>

--- a/geoportailv3/static/js/layermanager/layermanager.html
+++ b/geoportailv3/static/js/layermanager/layermanager.html
@@ -8,7 +8,7 @@
     </a>
     <div id="layermanager-item-{{$index}}" class="collapse">
       <a href ng-click="ctrl.changeVisibility(layer)"><span class="fa" ng-class="(layer.opacity > 0) ? 'fa-eye': 'fa-eye-slash'" ></span></a>
-      <input class="opacity" type="range" min="0" max="1" step="0.05" ng-model="layer.opacity" />
+      <input class="opacity" type="range" min="0" max="1" step="0.25" ng-model="layer.opacity" />
       <a class="delete" ng-click="ctrl.removeLayer(layer);"><span class="fa fa-trash-o"></span></a>
     </div>
   </li>

--- a/geoportailv3/static/js/layermanager/layermanagerdirective.js
+++ b/geoportailv3/static/js/layermanager/layermanagerdirective.js
@@ -60,4 +60,13 @@ app.LayermanagerController.prototype.removeLayer = function(layer) {
 };
 
 
+/**
+ * @param {ol.layer.Layer} layer Layer.
+ * @export
+ */
+app.LayermanagerController.prototype.changeVisibility = function(layer) {
+  layer.set('opacity', layer.get('opacity') > 0 ? 0 : 1);
+};
+
+
 app.module.controller('AppLayermanagerController', app.LayermanagerController);

--- a/geoportailv3/static/js/layermanager/layermanagerdirective.js
+++ b/geoportailv3/static/js/layermanager/layermanagerdirective.js
@@ -65,7 +65,17 @@ app.LayermanagerController.prototype.removeLayer = function(layer) {
  * @export
  */
 app.LayermanagerController.prototype.changeVisibility = function(layer) {
-  layer.set('opacity', layer.get('opacity') > 0 ? 0 : 1);
+  var currentOpacity = parseFloat(layer.get('opacity'));
+  var newOpacity;
+  if (currentOpacity === 0) {
+    newOpacity = layer.get('oldOpacity') ? layer.get('oldOpacity') : 1;
+    // reset oldOpacity for later use
+    layer.set('oldOpacity', undefined);
+  } else {
+    layer.set('oldOpacity', currentOpacity);
+    newOpacity = 0;
+  }
+  layer.set('opacity', newOpacity);
 };
 
 

--- a/geoportailv3/static/js/layermanager/layermanagerdirective.js
+++ b/geoportailv3/static/js/layermanager/layermanagerdirective.js
@@ -65,7 +65,7 @@ app.LayermanagerController.prototype.removeLayer = function(layer) {
  * @export
  */
 app.LayermanagerController.prototype.changeVisibility = function(layer) {
-  var currentOpacity = parseFloat(layer.get('opacity'));
+  var currentOpacity = parseFloat(layer.getOpacity());
   var newOpacity;
   if (currentOpacity === 0) {
     newOpacity = layer.get('oldOpacity') ? layer.get('oldOpacity') : 1;

--- a/geoportailv3/static/js/layermanager/layermanagerdirective.js
+++ b/geoportailv3/static/js/layermanager/layermanagerdirective.js
@@ -68,7 +68,8 @@ app.LayermanagerController.prototype.changeVisibility = function(layer) {
   var currentOpacity = layer.getOpacity();
   var newOpacity;
   if (currentOpacity === 0) {
-    newOpacity = layer.get('oldOpacity') ? layer.get('oldOpacity') : 1;
+    var oldOpacity = layer.get('oldOpacity');
+    newOpacity = goog.isDef(oldOpacity) ? oldOpacity : 1;
     // reset oldOpacity for later use
     layer.set('oldOpacity', undefined);
   } else {

--- a/geoportailv3/static/js/layermanager/layermanagerdirective.js
+++ b/geoportailv3/static/js/layermanager/layermanagerdirective.js
@@ -65,7 +65,7 @@ app.LayermanagerController.prototype.removeLayer = function(layer) {
  * @export
  */
 app.LayermanagerController.prototype.changeVisibility = function(layer) {
-  var currentOpacity = parseFloat(layer.getOpacity());
+  var currentOpacity = layer.getOpacity();
   var newOpacity;
   if (currentOpacity === 0) {
     newOpacity = layer.get('oldOpacity') ? layer.get('oldOpacity') : 1;

--- a/geoportailv3/static/js/layermanager/layermanagerdirective.js
+++ b/geoportailv3/static/js/layermanager/layermanagerdirective.js
@@ -69,14 +69,15 @@ app.LayermanagerController.prototype.changeVisibility = function(layer) {
   var newOpacity;
   if (currentOpacity === 0) {
     var oldOpacity = layer.get('oldOpacity');
-    newOpacity = goog.isDef(oldOpacity) ? oldOpacity : 1;
+    newOpacity = goog.isDef(oldOpacity) ?
+        /** @type {number} */ (oldOpacity) : 1;
     // reset oldOpacity for later use
     layer.set('oldOpacity', undefined);
   } else {
     layer.set('oldOpacity', currentOpacity);
     newOpacity = 0;
   }
-  layer.set('opacity', newOpacity);
+  layer.setOpacity(newOpacity);
 };
 
 


### PR DESCRIPTION
With this pull request, the opacity and visibility now work together.
Moving the opacity slider to the left will display a slashed eye.
Clicking on the eye will change the opacity to 0 and thus will move the slider automatically to the left.
When the slashed eye is clicked:
 - the opacity is changed to 1 if the slider was manually moved to the left,
 - the opacity is changed to the previously known opacity if the visibility was changed by clicking on the eye.