### PR TITLE
Add background layer selector

### DIFF
--- a/geoportailv3/static/js/backgroundlayer/backgroundlayer.html
+++ b/geoportailv3/static/js/backgroundlayer/backgroundlayer.html
@@ -1,0 +1,13 @@
+<div class="text-center">
+  <span translate>Background layer:</span>&nbsp;
+  <div class="dropdown">
+    <button type="button" class="btn btn-default" data-toggle="dropdown">
+      {{ctrl.bgLayer.name}} <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+      <li ng-repeat="layer in ::ctrl.bgLayers">
+        <a href ng-click="ctrl.setLayer(layer)">{{layer.name}}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/geoportailv3/static/js/backgroundlayer/backgroundlayerdirective.js
+++ b/geoportailv3/static/js/backgroundlayer/backgroundlayerdirective.js
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview This file provides the "backgroundlayer" directive. This
+ * directive is used to create a dropdown for selecting the map's background
+ * layer. This directive is based on Bootstrap's "dropdown" component, and
+ * on the "ngeoBackgroundLayerMgr" service.
+ *
+ * Example:
+ *
+ * <app-backgroundlayer app-backgroundlayer-map="::mainCtrl.map">
+ * </app-backgroundlayer>
+ *
+ * Note the use of the one-time binding operator (::) in the map expression.
+ * One-time binding is used because we know the map is not going to change
+ * during the lifetime of the application.
+ */
+goog.provide('app.backgroundlayerDirective');
+
+goog.require('app');
+goog.require('app.GetWmtsLayer');
+goog.require('ngeo.BackgroundLayerMgr');
+
+
+/**
+ * @param {string} appBackgroundlayerTemplateUrl URL to backgroundlayer
+ *     template.
+ * @return {angular.Directive} The Directive Definition Object.
+ * @ngInject
+ */
+app.backgroundlayerDirective = function(appBackgroundlayerTemplateUrl) {
+  return {
+    restrict: 'E',
+    scope: {
+      'map': '=appBackgroundlayerMap'
+    },
+    controller: 'AppBackgroundlayerController',
+    controllerAs: 'ctrl',
+    bindToController: true,
+    templateUrl: appBackgroundlayerTemplateUrl
+  };
+};
+
+
+app.module.directive('appBackgroundlayer', app.backgroundlayerDirective);
+
+
+
+/**
+ * @constructor
+ * @param {ngeo.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer
+ *     manager.
+ * @param {app.GetWmtsLayer} appGetWmtsLayer Get WMTS layer function.
+ * @export
+ * @ngInject
+ */
+app.BackgroundlayerController = function(ngeoBackgroundLayerMgr,
+    appGetWmtsLayer) {
+
+  /**
+   * @type {ngeo.BackgroundLayerMgr}
+   * @private
+   */
+  this.backgroundLayerMgr_ = ngeoBackgroundLayerMgr;
+
+  /**
+   * @type {app.GetWmtsLayer}
+   * @private
+   */
+  this.getWmtsLayer_ = appGetWmtsLayer;
+
+  /**
+   * @type {ol.layer.Tile}
+   * @private
+   */
+  this.blankLayer_ = new ol.layer.Tile();
+
+  // FIXME the list of background layers will be provided by c2cgeoportal's
+  // "themes" web service.
+  this['bgLayers'] = [{
+    'name': 'blank'
+  }, {
+    'name': 'basemap_global'
+  }];
+
+  var bgLayer = this['bgLayer'] = this['bgLayers'][1];
+
+  this.setLayer(bgLayer);
+};
+
+
+/**
+ * @param {Object} layerSpec Layer specificacion object.
+ * @export
+ */
+app.BackgroundlayerController.prototype.setLayer = function(layerSpec) {
+  this['bgLayer'] = layerSpec;
+  var layerName = layerSpec['name'];
+  var layer = layerName === 'blank' ?
+      this.blankLayer_ : this.getWmtsLayer_(layerName);
+  this.backgroundLayerMgr_.set(this['map'], layer);
+};
+
+
+app.module.controller('AppBackgroundlayerController',
+    app.BackgroundlayerController);

--- a/geoportailv3/static/js/main.js
+++ b/geoportailv3/static/js/main.js
@@ -10,6 +10,7 @@
 goog.provide('app_main');
 
 goog.require('app.MainController');
+goog.require('app.backgroundlayerDirective');
 goog.require('app.catalogDirective');
 goog.require('app.layermanagerDirective');
 goog.require('app.scalelineDirective');

--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -10,7 +10,6 @@
 goog.provide('app.MainController');
 
 goog.require('app');
-goog.require('app.GetWmtsLayer');
 goog.require('ngeo.mapDirective');
 goog.require('ol.Map');
 goog.require('ol.View');
@@ -26,13 +25,11 @@ goog.require('ol.tilegrid.WMTS');
  * @param {angular.Scope} $scope Scope.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {string} langUrlTemplate Language URL template.
- * @param {app.GetWmtsLayer} appGetWmtsLayer Get WMTS layer function.
  * @constructor
  * @export
  * @ngInject
  */
-app.MainController = function($scope, gettextCatalog, langUrlTemplate,
-    appGetWmtsLayer) {
+app.MainController = function($scope, gettextCatalog, langUrlTemplate) {
 
   /**
    * @type {angularGettext.Catalog}
@@ -45,12 +42,6 @@ app.MainController = function($scope, gettextCatalog, langUrlTemplate,
    * @private
    */
   this.langUrlTemplate_ = langUrlTemplate;
-
-  /**
-   * @type {app.GetWmtsLayer}
-   * @private
-   */
-  this.getWmtsLayer_ = appGetWmtsLayer;
 
   /**
    * @type {Boolean}
@@ -91,7 +82,6 @@ app.MainController.prototype.setMap_ = function() {
 
   /** @type {ol.Map} */
   this['map'] = new ol.Map({
-    layers: [this.getWmtsLayer_('basemap_global')],
     view: new ol.View({
       center: ol.proj.transform([6, 49.7], 'EPSG:4326', 'EPSG:3857'),
       zoom: 8

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -132,10 +132,10 @@
     <script src="${request.static_url('%s/angular-gettext/dist/angular-gettext.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular-animate/angular-animate.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/closure/goog/base.js' % closure_library_path)}"></script>
+    <script src="${request.static_url('%s/bootstrap/dist/js/bootstrap.js' % node_modules_path)}"></script>
     <script src="${request.route_url('deps.js')}"></script>
     <script src="${request.static_url('geoportailv3:static/js/main.js')}"></script>
     <script src="${request.static_url('%s/ngeo/utils/watchwatchers.js' % node_modules_path)}"></script>
-    <script src="${request.static_url('%s/bootstrap/dist/js/bootstrap.js' % node_modules_path)}"></script>
 % else:
     <script src="${request.static_url('%s/jquery/dist/jquery.min.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/angular/angular.min.js' % node_modules_path)}"></script>

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -51,6 +51,7 @@
           <button class="close-panel" ng-click="mainCtrl.sidebarOpen = false;">
             ✕
           </button>
+          <app-backgroundlayer app-backgroundlayer-map="::mainCtrl.map"></app-backgroundlayer>
           <ul class="nav nav-tabs">
             <li role="presentation" class="active">
             <a href="#mylayers" data-toggle="tab">{{'my_layers'|translate}}
@@ -152,6 +153,8 @@
 
          appModule.value('ngeoLayertreeTemplateUrl', '${request.static_url('geoportailv3:static/js/catalog/layertree.html')}');
          appModule.value('ngeoLayertreenodeTemplateUrl', '${request.static_url('geoportailv3:static/js/catalog/layertreenode.html')}');
+
+         appModule.value('appBackgroundlayerTemplateUrl', '${request.static_url('geoportailv3:static/js/backgroundlayer/backgroundlayer.html')}');
          appModule.value('appLayermanagerTemplateUrl', '${request.static_url('geoportailv3:static/js/layermanager/layermanager.html')}');
        })();
     </script>

--- a/less/sidebar.less
+++ b/less/sidebar.less
@@ -24,6 +24,18 @@
     }
   }
 
+  app-backgroundlayer {
+    > div {
+      margin-bottom: 15px;
+      .dropdown {
+        display: inline-block;
+        button {
+          min-width: 120px;
+        }
+      }
+    }
+  }
+
   &> div {
     height: 100%;
   }

--- a/less/sidebar.less
+++ b/less/sidebar.less
@@ -51,8 +51,12 @@
   }
 
   #layers .tab-content {
-    // 100% - h2 font-size - padding-top - padding-bottom - tab font-size - tab padding*2;
-    height: ~"calc(100% - 40px - 2 * 12px - 24px - 2 * 10px)";
+    // Height calculation:
+    // 100% - h2 font-size - padding-top - padding-bottom -
+    //   (app-backgroundlayer) @input-height-base - margin-bottom -
+    //   tab font-size - tab padding*2;
+    // FIXME: use variables for the calculation
+    height: ~"calc(100% - 40px - 2 * 12px - @{input-height-base} - 15px - 24px - 2 * 10px)";
     overflow: auto;
   }
 }


### PR DESCRIPTION
This PR adds a background layer selector based on Angular UI Bootstrap's `dropdown` directive and ngeo's `ngeoBackgroundLayerMgr` service.

This is what it looks like for the moment:

![backgroundlayer](https://cloud.githubusercontent.com/assets/76594/5798898/933019a8-9fcc-11e4-882f-0a2cbc0ad77a.png)

Work on the CSS is needed. In particular, the list is not correctly centered:

![backgroundlayer-list](https://cloud.githubusercontent.com/assets/76594/5798916/c6d25a8c-9fcc-11e4-86a3-b9d34da8dd9b.png)

Things to do:

- [x] Decide if we use Angular UI Bootstrap (this implies changing other parts of the application)
- [x] Review and fix CSS (with @pgiraud)
- [ ] Rely on catalog web service instead of hard-coding the list of background layers

