### PR TITLE
Use Shapely 1.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 --index-url http://pypi.camptocamp.net/pypi
 --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal
+shapely==1.5.3
 -e git+https://github.com/camptocamp/pyramid_closure#egg=pyramid_closure
 -e git+https://github.com/transifex/transifex-client.git@fix-proxies#egg=transifex-client-proxies
 -e .


### PR DESCRIPTION
This is to workaround https://github.com/Toblerity/Shapely/issues/231, which prevents us from installing Shapely 1.5.4.

Let's see what Travis says.

Fixes #167.