### PR TITLE
Panels for tools using ngeo-btn-group

### DIFF
--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -46,12 +46,12 @@ app.MainController = function($scope, gettextCatalog, langUrlTemplate) {
   /**
    * @type {Boolean}
    */
-  this['sidebarOpen'] = false;
+  this['drawOpen'] = false;
 
   /**
    * @type {Boolean}
    */
-  this['mymapsOpen'] = false;
+  this['infosOpen'] = false;
 
   /**
    * @type {Boolean}
@@ -61,7 +61,27 @@ app.MainController = function($scope, gettextCatalog, langUrlTemplate) {
   /**
    * @type {Boolean}
    */
-  this['infosOpen'] = false;
+  this['measureOpen'] = false;
+
+  /**
+   * @type {Boolean}
+   */
+  this['mymapsOpen'] = false;
+
+  /**
+   * @type {Boolean}
+   */
+  this['printOpen'] = false;
+
+  /**
+   * @type {Boolean}
+   */
+  this['shareOpen'] = false;
+
+  /**
+   * @type {Boolean}
+   */
+  this['sidebarOpen'] = false;
 
   /**
    * @type {Array}

--- a/geoportailv3/static/less/navbars.less
+++ b/geoportailv3/static/less/navbars.less
@@ -38,6 +38,20 @@ header {
     /* force items to appear on the same line even for small screens */
     display: inline-block;
   }
+
+  .toolbox-panel {
+    display: none;
+    position: absolute;
+    top: auto;
+    bottom: 100%;
+    white-space: nowrap;
+    background-color: white;
+    border: 1px solid;
+  }
+
+  .active .toolbox-panel {
+    display: block;
+  }
 }
 
 .sidebar-controls {

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -113,17 +113,23 @@
         <li><a href translate>item2</a></li>
         <li><a href translate>item3</a></li>
       </ul>
-      <ul class="toolbox nav navbar-nav">
-        <li class="hidden-xs draw icon">
-          <a href translate>draw</a>
+      <ul class="toolbox nav navbar-nav" ngeo-btn-group>
+        <li class="hidden-xs draw icon" ng-class="mainCtrl.drawOpen ? 'active' : ''">
+          <a href translate ngeo-btn ng-model="mainCtrl.drawOpen">draw</a>
+          <div class="toolbox-panel">The panel for draw tools</div>
         </li>
-        <li class="hidden-xs measure icon">
-          <a href translate>measure</a>
+        <li class="hidden-xs measure icon" ng-class="mainCtrl.measureOpen ? 'active' : ''">
+          <a href translate ngeo-btn ng-model="mainCtrl.measureOpen">measure</a>
+          <div class="toolbox-panel">The panel for measure tools</div>
         </li>
-        <li class="hidden-xs print icon">
-          <a href translate>print</a>
+        <li class="hidden-xs print icon" ng-class="mainCtrl.printOpen ? 'active' : ''">
+          <a href translate ngeo-btn ng-model="mainCtrl.printOpen">print</a>
+          <div class="toolbox-panel">The panel for print tools</div>
         </li>
-        <li class="share icon"><a class="square" href="#" translate>share</a></li>
+        <li class="share icon" ng-class="mainCtrl.shareOpen ? 'active' : ''">
+          <a href translate ngeo-btn ng-model="mainCtrl.shareOpen">share</a>
+          <div class="toolbox-panel">The panel for share tools</div>
+        </li>
       </ul>
     </footer>
 % if debug:


### PR DESCRIPTION
The goal of those changes is to prepare the work for the toolboxes (button with an attached panel which open when the button is clicked).
We use a ngeo-btn-group so that when a toolbox panel is shown the other toolboxes are hidden.

The same work needs to be done for the top right buttons (login, languages).