### PR TITLE
 Remove mainCtrl.sidebarOpen

### DIFF
--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -54,12 +54,12 @@ app.MainController = function($scope, gettextCatalog, langUrlTemplate,
   this.defaultExtent_ = defaultExtent;
 
   /**
-   * @type {Boolean}
+   * @type {boolean}
    */
   this['languageOpen'] = false;
 
   /**
-   * @type {Boolean}
+   * @type {boolean}
    */
   this['drawOpen'] = false;
 

--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -94,18 +94,12 @@ app.MainController = function($scope, gettextCatalog, langUrlTemplate,
   this['shareOpen'] = false;
 
   /**
-   * @type {boolean}
-   */
-  this['sidebarOpen'] = false;
-
-  /**
    * @type {Array}
    */
   this['selectedLayers'] = [];
 
   this.setMap_();
   this.switchLanguage('fr');
-  this.manageSidebar_($scope);
   this.manageSelectedLayers_($scope);
 };
 
@@ -156,6 +150,23 @@ app.MainController.prototype.manageSelectedLayers_ = function(scope) {
 
 
 /**
+ * @export
+ */
+app.MainController.prototype.closeSidebar = function() {
+  this['mymapsOpen'] = this['layersOpen'] = this['infosOpen'] = false;
+};
+
+
+/**
+ * @return {boolean} `true` if the sidebar should be open, otherwise `false`.
+ * @export
+ */
+app.MainController.prototype.sidebarOpen = function() {
+  return this['mymapsOpen'] || this['layersOpen'] || this['infosOpen'];
+};
+
+
+/**
  * @param {string} lang Language code.
  * @export
  */
@@ -164,41 +175,6 @@ app.MainController.prototype.switchLanguage = function(lang) {
   this.gettextCatalog_.loadRemote(
       this.langUrlTemplate_.replace('__lang__', lang));
   this['lang'] = lang;
-};
-
-
-/**
- * @param {angular.Scope} scope Scope.
- * @private
- */
-app.MainController.prototype.manageSidebar_ = function(scope) {
-
-  var toggleSidebar = goog.bind(function(newVal, oldVal) {
-    this['sidebarOpen'] = this['mymapsOpen'] || this['layersOpen'] ||
-        this['infosOpen'];
-  }, this);
-
-  scope.$watch(goog.bind(function() {
-    return this['mymapsOpen'];
-  }, this), toggleSidebar);
-
-  scope.$watch(goog.bind(function() {
-    return this['layersOpen'];
-  }, this), toggleSidebar);
-
-  scope.$watch(goog.bind(function() {
-    return this['infosOpen'];
-  }, this), toggleSidebar);
-
-  scope.$watch(goog.bind(function() {
-    return this['sidebarOpen'];
-  }, this), goog.bind(function(newVal, oldVal) {
-    if (!newVal) {
-      this['mymapsOpen'] = false;
-      this['layersOpen'] = false;
-      this['infosOpen'] = false;
-    }
-  }, this));
 };
 
 

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -60,11 +60,11 @@
 
     <!-- Begin page content (ie. map + left sidebar) -->
     <div id="main-container">
-      <div id="sidebar" ng-class="mainCtrl.sidebarOpen ? 'open' : ''"
+      <div id="sidebar" ng-class="{open: mainCtrl.sidebarOpen()}"
            ngeo-resizemap="mainCtrl.map">
         <div id="layers" ng-class="mainCtrl.layersOpen ? 'show' : 'hide'">
           <h2 translate>layers</h2>
-          <button class="close-panel" ng-click="mainCtrl.sidebarOpen = false;">
+          <button class="close-panel" ng-click="mainCtrl.closeSidebar()">
             ✕
           </button>
           <app-backgroundlayer app-backgroundlayer-map="::mainCtrl.map"></app-backgroundlayer>
@@ -95,13 +95,13 @@
         </div>
         <div id="mymaps" ng-class="mainCtrl.mymapsOpen ? 'show' : 'hide'">
           <h2 translate>my_maps</h2>
-          <button class="close-panel" ng-click="mainCtrl.sidebarOpen = false;">
+          <button class="close-panel" ng-click="mainCtrl.closeSidebar()">
             ✕
           </button>
         </div>
         <div id="infos" ng-class="mainCtrl.infosOpen ? 'show' : 'hide'">
           <h2 translate>infos</h2>
-          <button class="close-panel" ng-click="mainCtrl.sidebarOpen = false;">
+          <button class="close-panel" ng-click="mainCtrl.closeSidebar()">
             ✕
           </button>
         </div>
@@ -114,7 +114,7 @@
     <!-- Begin bottom bar -->
     <footer class="footer">
       <ul class="sidebar-controls nav navbar-nav pull-left"
-          ng-class="mainCtrl.sidebarOpen ? 'open' : ''" ngeo-btn-group>
+          ng-class="{open: mainCtrl.sidebarOpen()}" ngeo-btn-group>
         <li ngeo-btn ng-model="mainCtrl.layersOpen" class="layers icon">
           <a href translate>layers</a>
         </li>


### PR DESCRIPTION
This PR removes the `mainCtrl.sidebarOpen` state and the four watchers that are necessary to keep it in sync with `layersOpen`, `mymapsOpen` and `infosOpen`.

With this PR we go from 243 to 239 watchers, 208 of which coming from the catalog directive (with the per-node watchers we need).