### PR TITLE
Add an appThemes service

### DIFF
--- a/geoportailv3/static/js/backgroundlayer/backgroundlayerdirective.js
+++ b/geoportailv3/static/js/backgroundlayer/backgroundlayerdirective.js
@@ -17,6 +17,7 @@ goog.provide('app.backgroundlayerDirective');
 
 goog.require('app');
 goog.require('app.GetWmtsLayer');
+goog.require('app.Themes');
 goog.require('ngeo.BackgroundLayerMgr');
 
 
@@ -48,11 +49,12 @@ app.module.directive('appBackgroundlayer', app.backgroundlayerDirective);
  * @constructor
  * @param {ngeo.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer
  *     manager.
+ * @param {app.Themes} appThemes Themes service.
  * @param {app.GetWmtsLayer} appGetWmtsLayer Get WMTS layer function.
  * @export
  * @ngInject
  */
-app.BackgroundlayerController = function(ngeoBackgroundLayerMgr,
+app.BackgroundlayerController = function(ngeoBackgroundLayerMgr, appThemes,
     appGetWmtsLayer) {
 
   /**
@@ -73,17 +75,15 @@ app.BackgroundlayerController = function(ngeoBackgroundLayerMgr,
    */
   this.blankLayer_ = new ol.layer.Tile();
 
-  // FIXME the list of background layers will be provided by c2cgeoportal's
-  // "themes" web service.
-  this['bgLayers'] = [{
-    'name': 'blank'
-  }, {
-    'name': 'basemap_global'
-  }];
-
-  var bgLayer = this['bgLayer'] = this['bgLayers'][1];
-
-  this.setLayer(bgLayer);
+  appThemes.getBgLayers().then(goog.bind(
+      /**
+       * @param {Array.<Object>} bgLayers Array of background layer objects.
+       */
+      function(bgLayers) {
+        this['bgLayers'] = bgLayers;
+        this['bgLayer'] = this['bgLayers'][0];
+        this.setLayer(this['bgLayer']);
+      }, this));
 };
 
 

--- a/geoportailv3/static/js/catalog/catalogdirective.js
+++ b/geoportailv3/static/js/catalog/catalogdirective.js
@@ -16,6 +16,7 @@ goog.provide('app.catalogDirective');
 
 goog.require('app');
 goog.require('app.GetLayerForCatalogNode');
+goog.require('app.Themes');
 goog.require('ngeo.layertreeDirective');
 
 
@@ -44,20 +45,20 @@ app.module.directive('appCatalog', app.catalogDirective);
 
 /**
  * @constructor
- * @param {angular.$http} $http Angular http service.
- * @param {string} treeUrl Catalog tree URL.
+ * @param {app.Themes} appThemes Themes service.
  * @param {app.GetLayerForCatalogNode} appGetLayerForCatalogNode Function to
  *     create layers from catalog nodes.
  * @export
  * @ngInject
  */
-app.CatalogController = function($http, treeUrl, appGetLayerForCatalogNode) {
-  $http.get(treeUrl).then(goog.bind(
+app.CatalogController = function(appThemes, appGetLayerForCatalogNode) {
+
+  appThemes.getThemeObject('main').then(goog.bind(
       /**
-       * @param {angular.$http.Response} resp Ajax response.
+       * @param {Object} tree Tree object for the theme.
        */
-      function(resp) {
-        this['tree'] = resp.data['items'][2];
+      function(tree) {
+        this['tree'] = tree;
       }, this));
 
   /**

--- a/geoportailv3/static/js/themesservice.js
+++ b/geoportailv3/static/js/themesservice.js
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview This file defines the Themes service. This service interacts
+ * with c2cgeoportal's "themes" web service and exposes functions that return
+ * objects in the tree returned by the "themes" web service.
+ */
+goog.provide('app.Themes');
+
+goog.require('app');
+goog.require('goog.asserts');
+
+
+/**
+ * @typedef {{themes: Array.<Object>, background_layers: Array.<Object>}}
+ */
+app.ThemesResponse;
+
+
+
+/**
+ * @constructor
+ * @param {angular.$http} $http Angular http service.
+ * @param {string} treeUrl URL to "themes" web service.
+ */
+app.Themes = function($http, treeUrl) {
+  /**
+   * @type {angular.$q.Promise}
+   * @private
+   */
+  this.promise_ = $http.get(treeUrl).then(
+      /**
+       * @param {angular.$http.Response} resp Ajax response.
+       * @return {Object} The "themes" web service response.
+       */
+      function(resp) {
+        return /** @type {app.ThemesResponse} */ (resp.data);
+      });
+};
+
+
+/**
+ * Find an object by its name.
+ * @param {Array.<Object>} objects Array of objects.
+ * @param {string} objectName The object name.
+ * @return {Object} The object.
+ * @private
+ */
+app.Themes.findObjectByName_ = function(objects, objectName) {
+  return goog.array.find(objects, function(object) {
+    return object['name'] === objectName;
+  });
+};
+
+
+/**
+ * Find a theme object by its name.
+ * @param {Array.<Object>} themes Array of "theme" objects.
+ * @param {string} themeName The theme name.
+ * @return {Object} The theme object.
+ * @private
+ */
+app.Themes.findTheme_ = function(themes, themeName) {
+  var theme = app.Themes.findObjectByName_(themes, themeName);
+  goog.asserts.assert(!goog.isNull(theme));
+  return theme;
+};
+
+
+/**
+ * Get background layers.
+ * @return {angular.$q.Promise} Promise.
+ */
+app.Themes.prototype.getBgLayers = function() {
+  return this.promise_.then(
+      /**
+       * @param {app.ThemesResponse} data The "themes" web service response.
+       * @return {Array.<Object>} Array of background layer objects.
+       */
+      function(data) {
+        return data['background_layers'];
+      });
+};
+
+
+/**
+ * Get a theme object by its name.
+ * @param {string} themeName Theme name.
+ * @return {angular.$q.Promise} Promise.
+ */
+app.Themes.prototype.getThemeObject = function(themeName) {
+  return this.promise_.then(
+      /**
+       * @param {app.ThemesResponse} data The "themes" web service response.
+       * @return {Object} The theme object for themeName.
+       */
+      function(data) {
+        var themes = data['themes'];
+        return app.Themes.findTheme_(themes, themeName);
+      });
+};
+
+
+/**
+ * The factory function creating the appThemes service.
+ * @param {angular.$http} $http Angular http service.
+ * @param {string} treeUrl URL to "themes" web service.
+ * @return {app.Themes} The themes service.
+ * @private
+ * @ngInject
+ */
+app.ThemesFactory_ = function($http, treeUrl) {
+  return new app.Themes($http, treeUrl);
+};
+
+
+app.module.factory('appThemes', app.ThemesFactory_);

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -183,7 +183,7 @@
            'fr': '${request.static_url('geoportailv3:static/build/locale/fr/geoportailv3.json')}',
            'lb': '${request.static_url('geoportailv3:static/build/locale/lb/geoportailv3.json')}'
          });
-         appModule.constant('treeUrl', "${request.route_url('themes', _query={'version': 2, 'min_levels': 1, 'catalogue': 'true', 'interface': 'desktop' })}");
+         appModule.constant('treeUrl', "${request.route_url('themes', _query={'version': 2, 'min_levels': 1, 'catalogue': 'true', 'interface': 'desktop', 'background': 'bglayers'})}");
          appModule.constant('loginUrl', "${request.route_url('login')}");
          appModule.constant('logoutUrl', "${request.route_url('logout')}");
          appModule.constant('getuserinfoUrl', "${request.route_url('getuserinfo')}");


### PR DESCRIPTION
This PR adds an `appThemes` service to the project's Angular application. This service requests the "themes" data from c2cgeoportal's `themes` web service, and provides functions to interact with that "themes" data. The service is used by the catalog and background layer directives.

Now that the background layer directive gets the list of background layers from the "themes" web service, we have 5 background layers in the background layer selector. BUT only two layers actually work: `basemap_global` and `topogr_global`. I would suggest that we look at the non-working background layers after merging this.

Please review.