### PR TITLE
Fix font awesome path

### DIFF
--- a/geoportailv3.mk
+++ b/geoportailv3.mk
@@ -19,6 +19,9 @@ CONFIG_VARS += ldap
 
 UTILITY_HELP = "- update-translations		Synchronize the translations with Transifex"
 
+# Add rule that copies the font-awesome fonts to the static/build directory.
+POST_RULES = .build/fonts.timestamp
+
 include CONST_Makefile
 
 DEV_REQUIREMENTS += git+https://github.com/transifex/transifex-client.git@fix-proxies#egg=transifex-client-proxies
@@ -31,3 +34,8 @@ update-translations: $(PACKAGE)/locale/$(PACKAGE)-server.pot $(PACKAGE)/locale/$
 	.build/venv/bin/tx pull -l fr
 	.build/venv/bin/tx pull -l de
 	.build/venv/bin/tx pull -l lb
+
+.build/fonts.timestamp: .build/node_modules.timestamp
+	mkdir -p $(PACKAGE)/static/build/fonts
+	cp node_modules/font-awesome/fonts/* $(PACKAGE)/static/build/fonts/
+	touch $@

--- a/geoportailv3/static/less/geoportailv3.less
+++ b/geoportailv3/static/less/geoportailv3.less
@@ -21,7 +21,7 @@
        url('../webfonts/28867F_0_0.ttf') format('truetype');
 }
 
-@fa-font-path:   "../../node_modules/font-awesome/fonts";
+@fa-font-path: "fonts";
 
 body {
   font-family: 'DINNextLTPro-Condensed', Arial, sans-serif;


### PR DESCRIPTION
This PR fixes the path to font-awesome fonts.

See https://github.com/Geoportail-Luxembourg/geoportailv3/commit/a6b8e9edafbec42245cb8706ba7b41d196ddc228#commitcomment-9981500.

Fixes #289.