### PR TITLE
Pre-cache directive partials

### DIFF
--- a/CONST_Makefile
+++ b/CONST_Makefile
@@ -75,6 +75,7 @@ OL_JS_FILES = $(shell find node_modules/openlayers/src/ol -type f -name '*.js' 2
 NGEO_JS_FILES = $(shell find node_modules/ngeo/src -type f -name '*.js' 2> /dev/null)
 APP_JS_FILES = $(shell find $(PACKAGE)/static/js -type f -name '*.js')
 APP_HTML_FILES = $(shell find $(PACKAGE)/templates -type f -name '*.html')
+APP_PARTIALS_FILES := $(shell find $(PACKAGE)/static/js -type f -name '*.html')
 LESS_FILES = $(shell find $(PACKAGE)/static/less -type f -name '*.less' 2> /dev/null)
 JSON_CLIENT_LOCALISATION_FILES = $(addprefix $(OUTPUT_DIR)/locale/, $(addsuffix /$(PACKAGE).json, $(LANGUAGES)))
 
@@ -420,8 +421,11 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	./node_modules/.bin/lessc $(PACKAGE)/static/less/$(PACKAGE).less $@
 
-.build/build.js: build.json $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) .build/externs/angular-1.3.js .build/externs/angular-1.3-q.js .build/externs/angular-1.3-http-promise.js .build/externs/jquery-1.9.js .build/node_modules.timestamp
+.build/build.js: build.json $(OL_JS_FILES) $(NGEO_JS_FILES) $(APP_JS_FILES) .build/templatecache.js .build/externs/angular-1.3.js .build/externs/angular-1.3-q.js .build/externs/angular-1.3-http-promise.js .build/externs/jquery-1.9.js .build/node_modules.timestamp
 	node tasks/build.js $< $@
+
+.build/templatecache.js: templatecache.mako.js
+	.build/venv/bin/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 
 .build/externs/angular-1.3.js:
 	mkdir -p $(dir $@)

--- a/build.json
+++ b/build.json
@@ -4,7 +4,8 @@
     "node_modules/openlayers/src/**/*.js",
     "node_modules/openlayers/build/ol.ext/**/*.js",
     "node_modules/ngeo/src/**/*.js",
-    "geoportailv3/static/js/**/*.js"
+    "geoportailv3/static/js/**/*.js",
+    ".build/templatecache.js"
   ],
   "compile": {
     "closure_entry_point": "app_main",

--- a/geoportailv3/static/js/authentication/authentication.html
+++ b/geoportailv3/static/js/authentication/authentication.html
@@ -1,4 +1,4 @@
-﻿<div class="navigation-account user-panel toolbox-panel toolbox-panel-top second-level">
+<div class="navigation-account user-panel toolbox-panel toolbox-panel-top second-level">
     <p class="menu-title" translate>My account</p>
     <form ng-if="!ctrl.isAuthenticated()" ng-submit="ctrl.authenticate(ctrl.credentials)">
         <fieldset>

--- a/geoportailv3/static/js/authentication/authentication.html
+++ b/geoportailv3/static/js/authentication/authentication.html
@@ -3,7 +3,6 @@
     <form ng-if="!ctrl.isAuthenticated()" ng-submit="ctrl.authenticate(ctrl.credentials)">
         <fieldset>
             <legend class="tab tab-account active" >Login</legend>
-            
             <div class="account-content">
                 <input type="text" ng-model="ctrl.credentials.login" placeholder="Login" />
                 <input type="password" ng-model="ctrl.credentials.password" placeholder="Password" />

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -193,11 +193,11 @@
          appModule.constant('internalWmsUrl', "${request.route_url('wms') })}");
          appModule.constant('defaultExtent', [425152.9429259216, 6324465.99999133, 914349.9239510496, 6507914.867875754]);
 
+% if debug:
          appModule.value('ngeoLayertreeTemplateUrl', '${request.static_url('geoportailv3:static/js/catalog/layertree.html')}');
          appModule.value('ngeoLayertreenodeTemplateUrl', '${request.static_url('geoportailv3:static/js/catalog/layertreenode.html')}');
          appModule.value('ngeoPopupTemplateUrl', '${request.static_url('geoportailv3:static/js/layerinfo/popup.html')}');
          appModule.value('ngeoScaleselectorTemplateUrl', '${request.static_url('geoportailv3:static/js/infobar/scaleselector.html')}');
-
          appModule.value('appBackgroundlayerTemplateUrl', '${request.static_url('geoportailv3:static/js/backgroundlayer/backgroundlayer.html')}');
          appModule.value('appLayermanagerTemplateUrl', '${request.static_url('geoportailv3:static/js/layermanager/layermanager.html')}');
          appModule.value('appMeasureTemplateUrl', '${request.static_url('geoportailv3:static/js/measure/measure.html')}');
@@ -205,6 +205,19 @@
          appModule.value('appAuthenticationTemplateUrl', '${request.static_url('geoportailv3:static/js/authentication/authentication.html')}');
          appModule.value('appInfobarTemplateUrl', '${request.static_url('geoportailv3:static/js/infobar/infobar.html')}');
          appModule.value('appProjectionselectorTemplateUrl', '${request.static_url('geoportailv3:static/js/infobar/projectionselector.html')}');
+% else:
+         appModule.value('ngeoLayertreeTemplateUrl', 'catalog/layertree.html');
+         appModule.value('ngeoLayertreenodeTemplateUrl', 'catalog/layertreenode.html');
+         appModule.value('ngeoPopupTemplateUrl', 'layerinfo/popup.html');
+         appModule.value('ngeoScaleselectorTemplateUrl', 'infobar/scaleselector.html');
+         appModule.value('appBackgroundlayerTemplateUrl', 'backgroundlayer/backgroundlayer.html');
+         appModule.value('appLayermanagerTemplateUrl', 'layermanager/layermanager.html');
+         appModule.value('appMeasureTemplateUrl', 'measure/measure.html');
+         appModule.value('appLayerinfoTemplateUrl', 'layerinfo/layerinfo.html');
+         appModule.value('appAuthenticationTemplateUrl', 'authentication/authentication.html');
+         appModule.value('appInfobarTemplateUrl', 'infobar/infobar.html');
+         appModule.value('appProjectionselectorTemplateUrl', 'infobar/projectionselector.html');
+% endif
        })();
     </script>
   </body>

--- a/templatecache.mako.js
+++ b/templatecache.mako.js
@@ -1,0 +1,43 @@
+## -*- coding: utf-8 -*-
+<%doc>
+    This is a Mako template that generates Angular code putting the contents of
+    HTML partials into Angular's $templateCache. The generated code is then built
+    with the rest of JavaScript code. The generated script is not used at all in
+    development mode, where HTML partials are loaded through Ajax.
+</%doc>
+<%
+  import re
+  import os
+  _partials = {}
+  for partial in partials.split(' '):
+      f = file(partial)
+      content = unicode(f.read().decode('utf8'))
+      content = re.sub(r'>\s*<' , '><', content)
+      content = re.sub(r'\s\s+', ' ', content)
+      content = re.sub(r'\n', '', content)
+      content = re.sub(r"'", "\\'", content)
+      dirname, filename = os.path.split(partial)
+      subdirname = os.path.basename(dirname.rstrip(os.sep))
+      _partials[os.path.join(subdirname, filename)] = content
+%>\
+/**
+ * @fileoverview Directive templates cache.
+ *
+ * GENERATED FILE. DO NOT EDIT.
+ */
+
+goog.require('app');
+
+(function() {
+  /**
+   * @param {angular.$cacheFactory.Cache} $templateCache
+   * @ngInject
+   */
+  var runner = function($templateCache) {
+  % for partial in _partials:
+    $templateCache.put('${partial}', '${_partials[partial]}');
+  %endfor
+  };
+
+  app.module.run(runner);
+})();\


### PR DESCRIPTION
Currently, the directive partials are downloaded by Angular with XHR requests at application init time, in both debug and non-debug mode. With this PR the directive partials are added to `build.js`, thereby avoiding extra requests in non-debug mode. The behavior is unchanged in debug mode: directive partials are still downloaded at application init time.

Please review.

Fixes #176.