### PR TITLE
Add proj4 to build.js

### DIFF
--- a/CONST_Makefile
+++ b/CONST_Makefile
@@ -409,7 +409,7 @@ $(PACKAGE)/locale/%/LC_MESSAGES/%/$(PACKAGE)-client.po: $(PACKAGE)/locale/$(PACK
 
 $(OUTPUT_DIR)/build.js: .build/node_modules.timestamp .build/build.js
 	mkdir -p $(dir $@)
-	awk 'FNR==1{print ""}1' $(addprefix node_modules/, jquery/dist/jquery.min.js angular/angular.min.js angular-gettext/dist/angular-gettext.min.js angular-animate/angular-animate.min.js bootstrap/dist/js/bootstrap.min.js) .build/build.js > $@
+	awk 'FNR==1{print ""}1' $(addprefix node_modules/, jquery/dist/jquery.min.js angular/angular.min.js angular-gettext/dist/angular-gettext.min.js angular-animate/angular-animate.min.js bootstrap/dist/js/bootstrap.min.js proj4/dist/proj4.js) .build/build.js > $@
 	sed -i '/^\/\/# sourceMappingURL=.*\.map$$/d' $@
 
 $(OUTPUT_DIR)/build.min.css: $(LESS_FILES) .build/node_modules.timestamp

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -174,7 +174,6 @@
     <script src="${request.static_url('%s/ngeo/utils/watchwatchers.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/proj4/dist/proj4-src.js' % node_modules_path)}"></script>
 % else:
-    <script src="${request.static_url('%s/proj4/dist/proj4-src.js' % node_modules_path)}"></script>
     <script src="${request.static_url('geoportailv3:static/build/build.js')}"></script>
 % endif
     <script>


### PR DESCRIPTION
As discussed in https://github.com/Geoportail-Luxembourg/geoportailv3/pull/250 `proj4.js` (the minified version) should be added/concatenated to the `build.js` build.

Fixes #307.