### PR TITLE
Disable measure tools when measure menu is closed

### DIFF
--- a/geoportailv3/static/js/measure/measuredirective.js
+++ b/geoportailv3/static/js/measure/measuredirective.js
@@ -126,9 +126,9 @@ app.MeasureController = function($scope, ngeoDecorateInteraction) {
     return this['active'];
   }, this), goog.bind(function(newVal) {
     if (newVal === false) {
-      this['measureLength'].active = false;
-      this['measureArea'].active = false;
-      this['measureAzimut'].active = false;
+      this['measureLength'].setActive(false);
+      this['measureArea'].setActive(false);
+      this['measureAzimut'].setActive(false);
     }
   }, this));
 };


### PR DESCRIPTION
This commit fixes a bug where the measure tools were not disabled when closing the measure menu. The problem only exists in non-debug mode. It is related to the "active" property being renamed by the compiler. The fix involves using setActive instead of setting the "active" property directly.

Fixes #319