### PR TITLE
Add the typeahead.js externs file

### DIFF
--- a/build.json
+++ b/build.json
@@ -19,6 +19,7 @@
       "node_modules/openlayers/externs/vbarray.js",
       "node_modules/ngeo/externs/angular-gettext.js",
       "node_modules/ngeo/externs/twbootstrap.js",
+      "node_modules/ngeo/externs/typeahead.js",
       ".build/externs/angular-1.3.js",
       ".build/externs/angular-1.3-q.js",
       ".build/externs/angular-1.3-http-promise.js",


### PR DESCRIPTION
With https://github.com/camptocamp/ngeo/pull/187 the ngeox.js externs file depends on externs defined in the typeahead.js externs file. So this requires adding the typeahead.js extens file to the project't build.json configuration file.