### PR TITLE
Get image type from layer spec

### DIFF
--- a/geoportailv3/static/js/layerfactoryservice.js
+++ b/geoportailv3/static/js/layerfactoryservice.js
@@ -22,7 +22,7 @@ app.GetWmtsLayer;
 
 
 /**
- * @typedef {function(string, string, string=):ol.layer.Image}
+ * @typedef {function(string, string, string, string=):ol.layer.Image}
  */
 app.GetWmsLayer;
 
@@ -123,16 +123,19 @@ app.getWmsLayer_ = function(ngeoDecorateLayer) {
    * @param {string} name WMS layer name.
    * @param {string} layers Comma-separated list of layer names for that WMS
    *     layer.
+   * @param {string} imageType Image type (e.g. "image/png").
    * @param {string=} opt_url WMS URL.
    * @return {ol.layer.Image} The layer.
    */
-  function getWmsLayer(name, layers, opt_url) {
+  function getWmsLayer(name, layers, imageType, opt_url) {
     var url = goog.isDef(opt_url) ?
         opt_url : 'http://devv3.geoportail.lu/main/wsgi/wms';
+    var imageExt = app.getImageExtension_(imageType);
     var layer = new ol.layer.Image({
       source: new ol.source.ImageWMS({
         url: url,
         params: {
+          'FORMAT': imageExt,
           'LAYERS': layers
         }
       })
@@ -179,7 +182,9 @@ app.getLayerForCatalogNode_ = function(appGetWmtsLayer, appGetWmsLayer) {
     if (type.indexOf('WMS') != -1) {
       goog.asserts.assert('name' in node);
       goog.asserts.assert('layers' in node);
-      layer = appGetWmsLayer(node['name'], node['layers'], node['url']);
+      goog.asserts.assert('imageType' in node);
+      layer = appGetWmsLayer(node['name'], node['layers'], node['imageType'],
+          node['url']);
     } else if (type == 'WMTS') {
       goog.asserts.assert('name' in node);
       goog.asserts.assert('imageType' in node);

--- a/geoportailv3/static/js/themesservice.js
+++ b/geoportailv3/static/js/themesservice.js
@@ -95,7 +95,9 @@ app.Themes.prototype.getBgLayers = function() {
        */
       function(data) {
         var bgLayers = data['background_layers'].map(goog.bind(function(item) {
-          var layer = this.getWmtsLayer_(item['name']);
+          goog.asserts.assert('name' in item);
+          goog.asserts.assert('imageType' in item);
+          var layer = this.getWmtsLayer_(item['name'], item['imageType']);
           layer.set('metadata', item['metadata']);
           return layer;
         }, this));


### PR DESCRIPTION
Fixes #355.

To be tested. But testing this requires a `themes` response with the `imageType` information.