### PR TITLE
Use a better way to disable print target

### DIFF
--- a/elemoine.mk
+++ b/elemoine.mk
@@ -1,7 +1,6 @@
 INSTANCE_ID = elemoine
 VARS_FILE = vars_${INSTANCE_ID}.yaml
-PRINT_OUTPUT = /tmp
-DISABLE_BUILD_RULES = apache
+DISABLE_BUILD_RULES = apache print
 
 include geoportailv3.mk
 


### PR DESCRIPTION
Before that PR I used `PRINT_OUTPUT = /tmp` in `elemoine.mk` to prevent the `print` target from failing. But that actually did not work as expected. This is the error I'm getting:

```
mv /tmp/print-elemoine.war /tmp
mv: ‘/tmp/print-elemoine.war’ and ‘/tmp/print-elemoine.war’ are the same file
make: *** [/tmp/print-elemoine.war] Error 1
```

This PR uses a better way to disable the `print` target in my environment. This is done by adding `print` to `DISABLE_BUILD_RULES`.