### PR TITLE
Better looking and more accessible checkboxes

### DIFF
--- a/geoportailv3/static/js/catalog/catalogdirective.js
+++ b/geoportailv3/static/js/catalog/catalogdirective.js
@@ -90,4 +90,20 @@ app.CatalogController.prototype.getLayer = function(node) {
 };
 
 
+/**
+ * Add or remove layer from map.
+ * @param {Object} node Tree node.
+ * @export
+ */
+app.CatalogController.prototype.toggle = function(node) {
+  var layer = this.getLayerFunc_(node);
+  var map = this['map'];
+  if (map.getLayers().getArray().indexOf(layer) >= 0) {
+    map.removeLayer(layer);
+  } else {
+    map.addLayer(layer);
+  }
+};
+
+
 app.module.controller('AppCatalogController', app.CatalogController);

--- a/geoportailv3/static/js/catalog/layertreenode.html
+++ b/geoportailv3/static/js/catalog/layertreenode.html
@@ -8,9 +8,10 @@
 </span>
 <div ng-if="!layertreenodeCtrl.node.children">
   <app-layerinfo app-layerinfo-layer="layertreenodeCtrl.layer"></app-layerinfo>
-  {{layertreenodeCtrl.node.name | translate}}
-  <input type="checkbox" ng-if="!layertreenodeCtrl.node.children"
-      ng-model="layertreenodeCtrl.getSetActive" ng-model-options="{getterSetter: true}"/>
+  <a href ng-click="catalogCtrl.toggle(layertreenodeCtrl.node)">
+    <i class="fa" ng-class="(layertreenodeCtrl.getSetActive()) ? 'fa-check-square' : 'fa-square'"></i>
+    {{layertreenodeCtrl.node.name | translate}}
+  </a>
 </div>
 <ul id="catalog-{{::layertreenodeCtrl.uid}}" ng-if="layertreenodeCtrl.node.children"
   ng-class="(layertreenodeCtrl.depth < 3) ? 'collapse' : ''">

--- a/geoportailv3/static/less/catalog.less
+++ b/geoportailv3/static/less/catalog.less
@@ -86,4 +86,10 @@ ul.catalog {
       }
     }
   }
+
+  .checkbox {
+    float: right;
+    margin: 0;
+    margin-right: 4px;
+  }
 }


### PR DESCRIPTION
I worked on the checkboxes in the catalog tree.
The idea was to push the checkboxes to the right. However I didn't find any way to make it correctly accessible.
I strongly think that it's a good thing to link the label (layer name) with the checkbox and group them into one single clickable element. Aligning the checkbox to the right makes things technically harder.
So, though it's a bit less comfortable visually, I think it works very well with what i did.

![screenshot from 2015-03-25 17 18 00](https://cloud.githubusercontent.com/assets/319774/6829303/f42f2342-d312-11e4-8c17-35e5697342c6.png)
