### PR TITLE
Fix compile errors

### DIFF
--- a/build.json
+++ b/build.json
@@ -63,7 +63,6 @@
       "missingGetCssName",
       "missingProperties",
       "missingProvide",
-      "missingRequire",
       "missingReturn",
       "newCheckTypes",
       "nonStandardJsDocs",
@@ -76,7 +75,8 @@
       "visibility"
     ],
     "jscomp_off": [
-      "unknownDefines"
+      "unknownDefines",
+      "missingRequire"
     ],
     "extra_annotation_name": [
       "api", "observable"

--- a/geoportailv3/static/js/locationcontrol.js
+++ b/geoportailv3/static/js/locationcontrol.js
@@ -7,6 +7,7 @@ goog.require('ol.Feature');
 goog.require('ol.FeatureOverlay');
 goog.require('ol.Geolocation');
 goog.require('ol.control.Control');
+goog.require('ol.geom.Point');
 
 
 goog.provide('app.LocationControl');

--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -16,6 +16,7 @@ goog.require('ngeo.SyncArrays');
 goog.require('ol.Map');
 goog.require('ol.View');
 goog.require('ol.control.FullScreen');
+goog.require('ol.control.Zoom');
 goog.require('ol.control.ZoomToExtent');
 goog.require('ol.layer.Tile');
 goog.require('ol.proj');

--- a/geoportailv3/static/js/measure/measuredirective.js
+++ b/geoportailv3/static/js/measure/measuredirective.js
@@ -20,6 +20,10 @@ goog.require('ngeo.interaction.MeasureAzimut');
 goog.require('ngeo.interaction.MeasureLength');
 goog.require('ol.format.GeoJSON');
 goog.require('ol.source.Vector');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Stroke');
+goog.require('ol.style.Style');
 
 
 /**

--- a/geoportailv3/static/js/profile/profiledirective.js
+++ b/geoportailv3/static/js/profile/profiledirective.js
@@ -17,7 +17,13 @@ goog.provide('app.profileDirective');
 goog.require('app');
 goog.require('ngeo');
 goog.require('ngeo.profileDirective');
+goog.require('ol.Feature');
 goog.require('ol.FeatureOverlay');
+goog.require('ol.Overlay');
+goog.require('ol.geom.Point');
+goog.require('ol.style.Circle');
+goog.require('ol.style.Fill');
+goog.require('ol.style.Style');
 
 
 /**


### PR DESCRIPTION
This PR fixes new compile errors that we now get because we use a more recent version of Closure Compiler.

See also https://github.com/camptocamp/ngeo/pull/207 and https://github.com/openlayers/ol3/pull/3511.