### PR TITLE
Add a layer opacity manager

### DIFF
--- a/geoportailv3/static/js/layeropacitymanagerservice.js
+++ b/geoportailv3/static/js/layeropacitymanagerservice.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview This file defines the "appLayerOpacityManager" service. This
+ * service (re-)sets the opacity of layers added to the map. The opacity is
+ * read from the layer's "start_opacity" metadata. If there's no metadata or
+ * if the "start_opacity" property doesn't exist then the layer opacity is
+ * reset to 1.
+ *
+ * Usage:
+ *
+ * appLayerOpacityManager.init(map);
+ *
+ */
+goog.provide('app.LayerOpacityManager');
+
+goog.require('app');
+goog.require('ol.CollectionEventType');
+
+
+
+/**
+ * @constructor
+ * @ngInject
+ */
+app.LayerOpacityManager = function() {
+};
+
+
+/**
+ * @param {ol.Map} map The map.
+ */
+app.LayerOpacityManager.prototype.init = function(map) {
+  var layers = map.getLayers();
+  goog.events.listen(layers, ol.CollectionEventType.ADD,
+      /**
+       * @param {ol.CollectionEventType} evt Collection event.
+       */
+      function(evt) {
+        var layer = /** @type {ol.layer.Layer} */ (evt.element);
+        var layerMetadata = layer.get('metadata');
+        var layerStartOpacity = goog.isDef(layerMetadata) &&
+            layerMetadata.hasOwnProperty('start_opacity') ?
+            +layerMetadata['start_opacity'] : 1;
+        layer.setOpacity(layerStartOpacity);
+      });
+};
+
+
+app.module.service('appLayerOpacityManager', app.LayerOpacityManager);

--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -11,6 +11,7 @@ goog.provide('app.MainController');
 
 goog.require('app');
 goog.require('app.ExclusionManager');
+goog.require('app.LayerOpacityManager');
 goog.require('app.LocationControl');
 goog.require('ngeo.SyncArrays');
 goog.require('ol.Map');
@@ -30,6 +31,8 @@ goog.require('ol.tilegrid.WMTS');
  * @param {angular.Scope} $scope Scope.
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @param {app.ExclusionManager} appExclusionManager Exclusion manager service.
+ * @param {app.LayerOpacityManager} appLayerOpacityManager Layer opacity
+ *     manager.
  * @param {Object.<string, string>} langUrls URLs to translation files.
  * @param {Array.<number>} defaultExtent Default geographical extent.
  * @param {ngeo.SyncArrays} ngeoSyncArrays
@@ -38,7 +41,7 @@ goog.require('ol.tilegrid.WMTS');
  * @ngInject
  */
 app.MainController = function($scope, gettextCatalog, appExclusionManager,
-    langUrls, defaultExtent, ngeoSyncArrays) {
+    appLayerOpacityManager, langUrls, defaultExtent, ngeoSyncArrays) {
 
   /**
    * @type {Array.<Object>}
@@ -123,11 +126,20 @@ app.MainController = function($scope, gettextCatalog, appExclusionManager,
    */
   this['currentTheme'] = 'main';
 
+  /**
+   * @type {ol.Map}
+   * @private
+   */
+  this.map_ = null;
+
   this.setMap_();
 
   this.switchLanguage('fr');
+
   this.manageSelectedLayers_($scope, ngeoSyncArrays);
+
   appExclusionManager.init(this.map_);
+  appLayerOpacityManager.init(this.map_);
 };
 
 
@@ -136,7 +148,6 @@ app.MainController = function($scope, gettextCatalog, appExclusionManager,
  */
 app.MainController.prototype.setMap_ = function() {
 
-  /** @type {ol.Map} */
   this.map_ = this['map'] = new ol.Map({
     controls: [
       new ol.control.Zoom({zoomInLabel: '\ue031', zoomOutLabel: '\ue025'}),


### PR DESCRIPTION
This commit adds a layer opacity manager service responsible for resetting the opacity of layers added to the map.

Fixes #381.