### PR TITLE
Adding map->profile interaction

### DIFF
--- a/geoportailv3/static/js/profile/profile.html
+++ b/geoportailv3/static/js/profile/profile.html
@@ -1,3 +1,4 @@
 <div class="profile" ngeo-profile="ctrl.profileData"
+    ngeo-profile-highlight="ctrl.profileHighlight"
     ngeo-profile-options="ctrl.profileOptions" ng-show="ctrl.profileOpen">
 </div>


### PR DESCRIPTION
This pull request aims to add an interaction between map and profile chart.

Please ensure that the `templatecache.js` file is updated.

I'm not super satisfied with the usability of the whole component for the following reasons:
 - the length of the line stays displayed and the hover tooltip may be displayed behind the length tooltip,
 - the tooltip "click to start drawing" is annoying once a line is drawn,
 - the point which shows the "hovered" distance is not visible enough.

Maybe we should:
 - remove the length tooltip once the line is drawn,
 - deactivate the measure length interaction until the user explicitly wants to draw a new line (button "new profile" somewhere).