### PR TITLE
Make pip download a zip for Pyramid

### DIFF
--- a/CONST_requirements.txt
+++ b/CONST_requirements.txt
@@ -2,6 +2,6 @@
 --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal
 --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal-win
 -r CONST_versions.txt
--e git+https://github.com/camptocamp/pyramid_closure@819bc43420b3cd924d8698c5a9606592c19dbb15#egg=pyramid_closure
+https://github.com/camptocamp/pyramid_closure/archive/819bc43420b3cd924d8698c5a9606592c19dbb15.zip#egg=pyramid_closure
 https://github.com/Pylons/pyramid/archive/1e02bbfc0df09259bf207112acf019c8dba44a90.zip#egg=pyramid
 -e .

--- a/CONST_requirements.txt
+++ b/CONST_requirements.txt
@@ -3,5 +3,5 @@
 --find-links http://pypi.camptocamp.net/internal-pypi/index/c2cgeoportal-win
 -r CONST_versions.txt
 -e git+https://github.com/camptocamp/pyramid_closure@819bc43420b3cd924d8698c5a9606592c19dbb15#egg=pyramid_closure
--e git+https://github.com/Pylons/pyramid@1e02bbfc0df09259bf207112acf019c8dba44a90#egg=pyramid
+https://github.com/Pylons/pyramid/archive/1e02bbfc0df09259bf207112acf019c8dba44a90.zip#egg=pyramid
 -e .


### PR DESCRIPTION
This commit makes pip download a zip archive for Pyramid instead using git. Using git leads to proxy-related issues, even if git+https is used, because Pyramid itself uses the git protocol for its pylons_sphinx_theme.git submodule.

Fixes #269.