### PR TITLE
Rebuild template cache when directive partials change

### DIFF
--- a/CONST_Makefile
+++ b/CONST_Makefile
@@ -476,7 +476,7 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 		.build/node_modules.timestamp
 	./node_modules/openlayers/node_modules/.bin/closure-util build $< $@
 
-.build/templatecache.js: templatecache.mako.js
+.build/templatecache.js: templatecache.mako.js $(APP_PARTIALS_FILES)
 	.build/venv/bin/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 
 .build/externs/angular-1.3.js:


### PR DESCRIPTION
This was removed in https://github.com/Geoportail-Luxembourg/geoportailv3/commit/c2ec0fa0d213e1afc86f487d5dc0572a9b74f7c5.

@sbrunner, this will need to be backported to c2cgeoportal.