### PR TITLE
Connect print directive to MapFish Print web service

### DIFF
--- a/build.json
+++ b/build.json
@@ -18,6 +18,7 @@
       "node_modules/openlayers/externs/topojson.js",
       "node_modules/ngeo/externs/angular-gettext.js",
       "node_modules/ngeo/externs/d3.js",
+      "node_modules/ngeo/externs/mapfish-print-v3.js",
       "node_modules/ngeo/externs/twbootstrap.js",
       "node_modules/ngeo/externs/typeahead.js",
       ".build/externs/angular-1.3.js",

--- a/elemoine.mk
+++ b/elemoine.mk
@@ -1,6 +1,11 @@
 INSTANCE_ID = elemoine
 VARS_FILE = vars_${INSTANCE_ID}.yaml
-DISABLE_BUILD_RULES = apache print
+
+DISABLE_BUILD_RULES = apache
+
+PRINT_OUTPUT = tomcat
+TOMCAT_STOP_COMMAND =
+TOMCAT_START_COMMAND =
 
 include geoportailv3.mk
 
@@ -13,3 +18,8 @@ dbtunnel:
 watchless:
 	@echo "Watching changes to less files…"
 	nosier -p geoportailv3/static/less "make -f elemoine.mk geoportailv3/static/build/build.css"
+
+.PHONY: tomcat
+tomcat:
+	@echo "Running Tomcat…"
+	docker run --rm -it -p 8080:8080 -e Xmx=2048m -v /home/elemoine/src/geoportailv3/tomcat:/deployment maluuba/tomcat7

--- a/geoportailv3/static/js/layerfactoryservice.js
+++ b/geoportailv3/static/js/layerfactoryservice.js
@@ -79,6 +79,7 @@ app.getWmtsLayer_ = function(ngeoDecorateLayer) {
         url: url,
         layer: name,
         matrixSet: 'GLOBAL_WEBMERCATOR',
+        format: imageType,
         requestEncoding: ol.source.WMTSRequestEncoding.REST,
         projection: ol.proj.get('EPSG:3857'),
         tileGrid: new ol.tilegrid.WMTS({
@@ -91,8 +92,8 @@ app.getWmtsLayer_ = function(ngeoDecorateLayer) {
             9.55462853565, 4.77731426782, 2.38865713391,
             1.19432856696, 0.597164283478, 0.298582141739],
           matrixIds: [
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 14, 15, 16, 17, 18, 19
+            '00', '01', '02', '03', '04', '05', '06', '07', '08', '09',
+            '10', '11', '12', '13', '14', '15', '16', '17', '18', '19'
           ]
         }),
         style: 'default'

--- a/geoportailv3/static/js/print/print.html
+++ b/geoportailv3/static/js/print/print.html
@@ -2,7 +2,9 @@
   <form>
     <div class="col-md-12">
       <div class="form-group">
-        <input type="text" class="form-control" name="title" placeholder="{{'Title'|translate}}">
+        <input type="text" class="form-control" name="title"
+               placeholder="{{'Title'|translate}}"
+               ng-model="ctrl.title">
       </div>
     </div>
     <div class="col-md-12">
@@ -16,18 +18,23 @@
       <div class="form-group">
         <select name="layout" class="form-control"
                 ng-model="ctrl.layout"
-                ng-options="layout as layout[0] | translate for layout in ctrl.layouts"></select>
+                ng-options="layout | translate for layout in ::ctrl.layouts"
+                ng-change="ctrl.changeLayout()">
+        </select>
       </div>
     </div>
     <div class="col-md-6">
       <div class="form-group">
         <select name="scale" class="form-control"
                 ng-model="ctrl.scale"
-                ng-options="scale as scale | translate for scale in ctrl.scales"></select>
+                ng-options="scale | translate for scale in ::ctrl.scales"
+                ng-change="ctrl.changeScale()">
+        </select>
       </div>
     </div>
     <div class="col-md-12">
-      <button type="submit" class="btn btn-default pull-right">PDF</button>
+      <button type="submit" class="btn btn-default pull-right"
+              ng-click="ctrl.print()">PDF</button>
     </div>
   </form>
 </div>

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -142,7 +142,7 @@
         </li>
         <li class="hidden-xs print icon" ng-class="mainCtrl.printOpen ? 'active' : ''">
           <a href translate ngeo-btn ng-model="mainCtrl.printOpen">print</a>
-          <app-print app-print-map="mainCtrl.map"></app-print>
+          <app-print app-print-map="::mainCtrl.map" app-print-open="mainCtrl.printOpen"></app-print>
         </li>
         <li class="share icon" ng-class="mainCtrl.shareOpen ? 'active' : ''">
           <a href translate ngeo-btn ng-model="mainCtrl.shareOpen">share</a>
@@ -192,6 +192,7 @@
          appModule.constant('elevationServiceUrl', "${request.route_url('raster')}");
          appModule.constant('profilejsonUrl', "${request.route_url('profile.json')}");
          appModule.constant('searchServiceUrl', "${request.route_url('fulltextsearch')}");
+         appModule.constant('printServiceUrl', "${request.route_url('printproxy')}");
          appModule.constant('defaultExtent', [425152.9429259216, 6324465.99999133, 914349.9239510496, 6507914.867875754]);
 
 % if debug:

--- a/vars_elemoine.yaml
+++ b/vars_elemoine.yaml
@@ -3,3 +3,6 @@ extends: vars_geoportailv3.yaml
 vars:
     # overwrite dbport for the ssh tunnel to the db
     dbport: 9999
+
+    # overwrite print_url for using a local install of Tomcat
+    print_url: http://localhost:8080/print-{instanceid}/print/{package}


### PR DESCRIPTION
This PR uses the new ngeo print services (https://github.com/camptocamp/ngeo/pull/204) to connect the print directives to the MapFish Print web service.

At this point only WMTS and single tile WMS layers are supported. Supporting printing vectors will be done with separate PRs.

Some UI-related work remains to be done. For example, there's no "wait" icon/message while the user waits for the generation of the print report. And there's no error message displayed when the MapFish Print service returns an error.

Yet, I think this can be reviewed and merged as-is.