### PR TITLE
Set closure compiler language in to ECMASCRIPT5_STRICT

### DIFF
--- a/build.json
+++ b/build.json
@@ -84,7 +84,8 @@
     "compilation_level": "ADVANCED",
     "warning_level": "VERBOSE",
     "generate_exports": true,
-    "output_wrapper": "(function(){%output%})();",
+    "language_in": "ECMASCRIPT5_STRICT",
+    "output_wrapper": "(function(){%output%}).call(window);",
     "use_types_for_optimization": true,
     "manage_closure_dependencies": true
   }


### PR DESCRIPTION
This is to follow a recent change made to the pyramid_closure scaffold: https://github.com/camptocamp/pyramid_closure/pull/54.