### PR TITLE
Use export_local_property_definitions Closure Compiler flag

### DIFF
--- a/build.json
+++ b/build.json
@@ -82,6 +82,7 @@
     ],
     "angular_pass": true,
     "compilation_level": "ADVANCED",
+    "export_local_property_definitions": true,
     "warning_level": "VERBOSE",
     "generate_exports": true,
     "language_in": "ECMASCRIPT5_STRICT",


### PR DESCRIPTION
Use `--export_local_property_definitions` in preparation for https://github.com/camptocamp/ngeo/pull/216.