### PR TITLE
Update jshint to latest stable version

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   // suppresses warnings about using [] notation (person['name']) W069
+  // /!\ this option will be removed in the next major release of jshint
   "sub": true,
   // suppresses errors that occur when adding @typedef
   "-W030": true

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "^3.3.0",
     "font-awesome": "4.2.0",
     "jquery": "^1.9.1",
-    "jshint": "~2.5.1",
+    "jshint": "2.7.0",
     "less": "~1.7.5",
     "ngeo": "camptocamp/ngeo#master",
     "nomnom": "~1.6.2",


### PR DESCRIPTION
This updates jshint to the latest version and get replace `"sub"` by `"-W069"` in the `.jshintrc` file, as using `"sub"` is [deprecated](https://github.com/camptocamp/schweizmobil_re3/pull/216).