### PR TITLE
Remove print description

### DIFF
--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -238,12 +238,10 @@ app.PrintController.prototype.print = function() {
   var scale = this['scale'];
   var layout = this['layout'];
 
-  // FIXME "description", "name", "url" and "qrimage" are harcoded at
-  // this point.
+  // FIXME "url" and "qrimage" are harcoded at this point.
 
   var spec = this.print_.createSpec(map, scale, dpi, layout, {
     'scale': scale,
-    'description': 'Description',
     'name': this['title'],
     'url': 'http://g-o.lu/0mf4r',
     'qrimage': 'http://dev.geoportail.lu/shorten/qr?url=http://g-o.lu/0mf4r'

--- a/print/print-apps/geoportailv3/a0_landscape.jrxml
+++ b/print/print-apps/geoportailv3/a0_landscape.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -60,13 +59,6 @@
 					<font fontName="DejaVu Sans" size="16" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="1337" y="20" width="555" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="14" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a0_portrait.jrxml
+++ b/print/print-apps/geoportailv3/a0_portrait.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -58,13 +57,6 @@
 					<font fontName="DejaVu Sans" size="16" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="848" y="20" width="555" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="14" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a1_landscape.jrxml
+++ b/print/print-apps/geoportailv3/a1_landscape.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -58,13 +57,6 @@
 					<font fontName="DejaVu Sans" size="16" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="850" y="20" width="555" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="14" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a1_portrait.jrxml
+++ b/print/print-apps/geoportailv3/a1_portrait.jrxml
@@ -14,7 +14,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -60,13 +59,6 @@
 					<font fontName="DejaVu Sans" size="16" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="630" y="20" width="555" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="14" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a2_landscape.jrxml
+++ b/print/print-apps/geoportailv3/a2_landscape.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -58,13 +57,6 @@
 					<font fontName="DejaVu Sans" size="16" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="630" y="20" width="555" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="14" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a2_portrait.jrxml
+++ b/print/print-apps/geoportailv3/a2_portrait.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -58,13 +57,6 @@
 					<font fontName="DejaVu Sans" size="16" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="380" y="20" width="555" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="14" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a3_landscape.jrxml
+++ b/print/print-apps/geoportailv3/a3_landscape.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -57,13 +56,6 @@
 					<font fontName="DejaVu Sans" size="16" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="330" y="20" width="555" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="14" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a3_portrait.jrxml
+++ b/print/print-apps/geoportailv3/a3_portrait.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -58,13 +57,6 @@
 					<font fontName="DejaVu Sans" size="12" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="260" y="14" width="180" height="23" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="10" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a4_landscape.jrxml
+++ b/print/print-apps/geoportailv3/a4_landscape.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -63,13 +62,6 @@
 					<font fontName="DejaVu Sans" size="12" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="275" y="13" width="232" height="36" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement>
-					<font fontName="DejaVu Sans" size="10" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<image scaleImage="RetainShape">
 				<reportElement x="0" y="0" width="230" height="51" uuid="70bbdaea-7cb7-4c97-b3ad-fd38c75a98ad"/>

--- a/print/print-apps/geoportailv3/a4_portrait.jrxml
+++ b/print/print-apps/geoportailv3/a4_portrait.jrxml
@@ -12,7 +12,6 @@
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
 	<parameter name="name" class="java.lang.String"/>
-	<parameter name="description" class="java.lang.String"/>
 	<parameter name="legend" class="net.sf.jasperreports.engine.data.JRTableModelDataSource"/>
 	<parameter name="legendSubReport" class="java.lang.String"/>
 	<parameter name="scale" class="java.lang.String">
@@ -61,13 +60,6 @@
 					<font fontName="DejaVu Sans" size="12" isBold="true" isItalic="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{name}]]></textFieldExpression>
-			</textField>
-			<textField>
-				<reportElement x="250" y="14" width="219" height="20" uuid="5b59bca0-4d72-4f52-889c-833479a3edc2"/>
-				<textElement textAlignment="Right">
-					<font fontName="DejaVu Sans" size="8" isBold="false" isItalic="true"/>
-				</textElement>
-				<textFieldExpression><![CDATA[$P{description}]]></textFieldExpression>
 			</textField>
 			<staticText>
 				<reportElement x="-21" y="55" width="21" height="347" forecolor="#E40520" uuid="f8a42822-0e3d-4802-ad70-024f9cc6677c"/>

--- a/print/print-apps/geoportailv3/config.yaml
+++ b/print/print-apps/geoportailv3/config.yaml
@@ -14,7 +14,6 @@ templates:
     reportTemplate: a4_portrait.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -48,7 +47,6 @@ templates:
     reportTemplate: a4_landscape.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -82,7 +80,6 @@ templates:
     reportTemplate: a3_portrait.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -116,7 +113,6 @@ templates:
     reportTemplate: a3_landscape.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -150,7 +146,6 @@ templates:
     reportTemplate: a2_portrait.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -184,7 +179,6 @@ templates:
     reportTemplate: a2_landscape.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -218,7 +212,6 @@ templates:
     reportTemplate: a1_portrait.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -252,7 +245,6 @@ templates:
     reportTemplate: a1_landscape.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -286,7 +278,6 @@ templates:
     reportTemplate: a0_portrait.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}
@@ -320,7 +311,6 @@ templates:
     reportTemplate: a0_landscape.jrxml
     attributes:
       name: !string {}
-      description: !string {}
       scale: !string {}
       url: !string {}
       qrimage: !string {}

--- a/print/print-apps/geoportailv3/requestData.json
+++ b/print/print-apps/geoportailv3/requestData.json
@@ -3,7 +3,6 @@
     "outputFormat": "pdf",
     "attributes": {
         "name": "Carte vélo exemple",
-        "description": "webmercator 668126, 6368118, 689717, 6389761 ",
         "scale": "60000",
         "url":"http://g-o.lu/0mf4r",
         "qrimage":"http://dev.geoportail.lu/shorten/qr?url=http://g-o.lu/0mf4r",


### PR DESCRIPTION
This PR removes the "description" field from the print config.

@jaykayone could you please review this? I am not sure about the changes to the MapFish Print config. I just removed every line that included "description" :-)

Fixes https://github.com/Geoportail-Luxembourg/geoportailv3/issues/469.