### PR TITLE
Fix bug in print directive

### DIFF
--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -152,8 +152,7 @@ app.PrintController = function($scope, $timeout, ngeoCreatePrint,
       goog.asserts.assert(goog.isNull(postcomposeListenerKey));
       postcomposeListenerKey = goog.events.listen(this.map_,
           ol.render.EventType.POSTCOMPOSE, postcomposeListener);
-    } else {
-      goog.asserts.assert(!goog.isNull(postcomposeListenerKey));
+    } else if (!goog.isNull(postcomposeListenerKey)) {
       goog.events.unlistenByKey(postcomposeListenerKey);
       postcomposeListenerKey = null;
     }


### PR DESCRIPTION
The print directive shouldn't assume that the print mask is displayed when the "open" watcher reports that "open" is false. Indeed, we get "open is false" each time another panel is opened.

Fixes https://github.com/Geoportail-Luxembourg/geoportailv3/issues/480.