### PR TITLE
Add a cancelPrint function to the print directive controller

### DIFF
--- a/geoportailv3/static/js/print/print.html
+++ b/geoportailv3/static/js/print/print.html
@@ -34,8 +34,10 @@
     </div>
     <div class="col-md-12 text-right">
       <span ng-if="ctrl.printing">
-      <i class="fa fa-refresh fa-spin"></i> {{'generating'|translate}}
-      &nbsp;
+        <i class="fa fa-refresh fa-spin"></i> {{'generating'|translate}}
+        &nbsp;
+        <a class="btn btn-link" ng-click="ctrl.cancel()" translate>Abort</a>
+        &nbsp;
       </span>
       <button type="submit" class="btn btn-default"
               ng-disabled="ctrl.printing"


### PR DESCRIPTION
This PR adds an exported `cancel` function to the print directive's controller. This function is to be called from the print directive's template when the user presses a "cancel print" button.

At this point the `cancel` function just cancels the current print request, if any. In addition, it should also send a "cancel job" to MapFish Print, but c2cgeoportal's `printproxy` does not currently support that operation. See https://github.com/camptocamp/c2cgeoportal/issues/1357.

Requires https://github.com/camptocamp/ngeo/pull/222.

Please review.