### PR TITLE
Change scale to optimal when changing print layout

### DIFF
--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -262,6 +262,7 @@ app.PrintController.prototype.cancel = function() {
  * @export
  */
 app.PrintController.prototype.changeLayout = function() {
+  this.useOptimalScale_();
   this.map_.render();
 };
 


### PR DESCRIPTION
As discussed with @pgiraud this PR changes the print scale to the optimal scale when the user changes the print layout. This prevents the bad experience that occurs when selecting A0 and not seeing the print mask because it's outside the current viewport.