### PR TITLE
Mobile specific layout for search input

### DIFF
--- a/geoportailv3/static/js/search/search.html
+++ b/geoportailv3/static/js/search/search.html
@@ -3,7 +3,7 @@
 </button>
 <form class="navbar-form" role="search">
     <div class="form-group">
-        <input type="text" class="form-control" placeholder="{{'search_key_words'|translate}}"
+        <input type="text" autocorrect="off" autocapitalize="none" class="form-control" placeholder="{{'search_key_words'|translate}}"
             ngeo-search="ctrl.options" ngeo-search-datasets="ctrl.datasets" ngeo-search-listeners="ctrl.listeners">
             <span class="clear-button" ng-click="click($event)">&#10005;</span>
         </input>

--- a/geoportailv3/static/js/search/search.html
+++ b/geoportailv3/static/js/search/search.html
@@ -1,4 +1,7 @@
-<form class="navbar-form pull-right hidden-xs" role="search">
+<button class="close-panel pull-right" ng-click="ctrl.mobileActive = false" ng-show="ctrl.mobileActive">
+  &#10005;
+</button>
+<form class="navbar-form" role="search">
     <div class="form-group">
         <input type="text" class="form-control" placeholder="{{'search_key_words'|translate}}"
             ngeo-search="ctrl.options" ngeo-search-datasets="ctrl.datasets" ngeo-search-listeners="ctrl.listeners">

--- a/geoportailv3/static/js/search/searchdirective.js
+++ b/geoportailv3/static/js/search/searchdirective.js
@@ -38,7 +38,8 @@ app.searchDirective = function(appSearchTemplateUrl) {
   return {
     restrict: 'E',
     scope: {
-      'map': '=appSearchMap'
+      'map': '=appSearchMap',
+      'mobileActive': '=appSearchMobileactive'
     },
     controller: 'AppSearchController',
     controllerAs: 'ctrl',

--- a/geoportailv3/static/less/layout.less
+++ b/geoportailv3/static/less/layout.less
@@ -62,6 +62,19 @@ app-map > div {
   }
 }
 
+.close-panel {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  background: none;
+  border: 0;
+  font-size: 36px;
+  padding: 2px;
+  line-height: 1;
+
+  &:hover {
+    opacity: 0.7;
+  }
+}
+
 #sidebar {
   display: block;
   width: @leftbar-width;
@@ -114,6 +127,10 @@ app-map > div {
     position: absolute;
     height: 0;
     bottom: 0;
+  }
+
+  .theme-icon {
+    display: none;
   }
 }
 
@@ -493,4 +510,8 @@ div.ol-zoom-extent > button {
     left: 10px;
     position: absolute;
   }
+}
+
+.navbar-form .form-group {
+  position: relative;
 }

--- a/geoportailv3/static/less/search.less
+++ b/geoportailv3/static/less/search.less
@@ -1,13 +1,17 @@
+@clear-button-width: 15px;
 span.twitter-typeahead {
     & + span.clear-button {
         position: absolute;
         top: 0;
-        margin: 15px 0px 0px 225px;
+        right: 0;
         display: none;
-        cursor: pointer; 
+        cursor: pointer;
         cursor: hand;
         color: white;
         opacity: 0.5;
+        padding: @padding-base-vertical 5px;
+        vertical-align: middle;
+        border: 1px solid transparent;
         &:hover {
             opacity: 1;
         }
@@ -27,8 +31,9 @@ span.twitter-typeahead {
     .form-control {
         min-width: 250px;
         position: relative;
-        padding-right: 32px;
+        padding-right: @clear-button-width;
         padding-left: 32px;
+        width: auto;
     }
     .tt-dropdown-menu {
         position: absolute;
@@ -91,6 +96,47 @@ span.twitter-typeahead {
     color: white;
   }
 
-  padding-right: 15px;
 }
 
+@media (min-width: @screen-sm-min) {
+  header .navbar-form {
+    float: right;
+    padding-right: 15px;
+  }
+}
+
+@media (max-width: @screen-xs-max) {
+  .navbar-form {
+    border: 0;
+  }
+
+  body:not(.search-mobile) app-search {
+    display: none;
+  }
+
+  /* Class search is added to body when on mobile && search button has been
+   * clicked */
+  .search-mobile {
+    header {
+      .navbar-nav,
+      .brand {
+        display: none;
+      }
+    }
+  }
+
+  app-search {
+    .navbar-form {
+      margin: 2px 40px 0 2px;
+
+      span.twitter-typeahead,
+      .form-control {
+        width: 100%;
+      }
+
+      span.twitter-typeahead .tt-dropdown-menu {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/geoportailv3/static/less/sidebar.less
+++ b/geoportailv3/static/less/sidebar.less
@@ -9,19 +9,10 @@
   }
 
   .close-panel {
-    font-size: 20px;
     position: absolute;
     right: 10px;
     top: 12px;
-    background: none;
-    border: 0;
     color: #fff;
-    font-size: 40px;
-    line-height: 1;
-
-    &:hover {
-      opacity: 0.7;
-    }
   }
 
   app-backgroundlayer {

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="${request.static_url('geoportailv3:static/build/build.min.css')}" type="text/css">
 % endif
   </head>
-  <body data-theme="{{mainCtrl.currentTheme}}">
+  <body data-theme="{{mainCtrl.currentTheme}}" ng-class="mainCtrl.mobileSearchActive ? 'search-mobile' : ''">
     <!-- Begin fixed top bar -->
     <header class="navbar navbar-default navbar-fixed-top" role="navigation">
       <div class="container-fluid">
@@ -29,7 +29,7 @@
         </div>
 
         <ul class="nav navbar-nav pull-right">
-          <li class="visible-xs-inline-block search icon"><a href translate>search</a></li>
+          <li class="visible-xs-inline-block search icon" ng-click="mainCtrl.mobileSearchActive = true"><a href translate>search</a></li>
           <li class="user icon" ng-class="mainCtrl.userOpen ? 'active': ''">
             <a href translate ngeo-btn ng-model="mainCtrl.userOpen" ng-click="mainCtrl.languageOpen = false">user</a>
             <app-authentication app-authentication-roleid="mainCtrl.roleId" app-authentication-lang="mainCtrl.lang"></app-authentication>
@@ -54,7 +54,8 @@
             </ul>
           </li>
         </ul>
-        <app-search app-search-map="::mainCtrl.map"></app-search>
+        <app-search app-search-map="::mainCtrl.map"
+                    app-search-mobileactive="mainCtrl.mobileSearchActive"></app-search>
         <button class="icon theme-icon pull-right"></button>
       </div>
     </header>


### PR DESCRIPTION
With this pull request I add the ability to do some search in devices with small screens (ie. mobile device).
When the user clicks on the _magnifier_ button, all the elements in the top bar are hidden, and the search input is displayed as well as a _cross_ button to get back to initial top bar.

This was a bit tricky and I'm not completely confident whether or not it will work on all devices.

There's also a usability issue for now since it would be good to have the keyboard being automatically shown when search input is displayed. Simply invoking `focus` on the input unfortunately doesn't seem to work on mobile devices (at least on safari iOS). I google a bit and tried several options without success.

Note : the list of results displays the same as in large screen devices.

![img_4422](https://cloud.githubusercontent.com/assets/319774/7838298/5f25ba3a-048c-11e5-83c5-126e55ba391c.PNG)
