### PR TITLE
WIP - Infobar adaptations for mobile

### DIFF
--- a/geoportailv3/static/js/infobar/infobar.html
+++ b/geoportailv3/static/js/infobar/infobar.html
@@ -4,10 +4,10 @@
             <app-scaleselector app-scaleselector-map="::ctrl.map"></app-scaleselector>
             <app-scaleline app-scaleline-map="::ctrl.map"></app-scaleline>
         </div>
-        <div class="projection-select">
+        <div class="projection-select hidden-xs hidden-sm">
             <app-projectionselector app-projectionselector-map="::ctrl.map" ></app-projectionselector>
         </div>
-        <div class="elevation-service">
+        <div class="elevation-service hidden-xs hidden-sm">
             <app-elevation app-elevation-map="::ctrl.map" app-elevation-active="ctrl.infobarOpen"></app-elevation>
         </div>
     </div>


### PR DESCRIPTION

Question for @pgiraud , how to change the infobar icon to use same iconset and method like other icons on page ? for the moment, the infobar icon on mobile does not look as wanted. 


![screenshot_2015-06-03-16-15-02](https://cloud.githubusercontent.com/assets/2540428/7962575/64d066e2-0a0e-11e5-8586-fff6de5c579f.png)