### PR TITLE
Replace ol.FeatureOverlay by appVectorOverlay

### DIFF
--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -165,9 +165,24 @@ app.MainController = function($scope, ngeoGetBrowserLanguage, gettextCatalog,
   appLayerOpacityManager.init(this.map_);
   appVectorOverlayMgr.init(this.map_);
 
+  this.addLocationControl_(appVectorOverlayMgr);
+
   this.manageUserRoleChange_($scope);
 
   this.loadThemes_();
+};
+
+
+/**
+ * @param {app.VectorOverlayMgr} vectorOverlayMgr Vector overlay manager.
+ * @private
+ */
+app.MainController.prototype.addLocationControl_ = function(vectorOverlayMgr) {
+  this.map_.addControl(
+      new app.LocationControl({
+        label: '\ue800',
+        vectorOverlayMgr: vectorOverlayMgr
+      }));
 };
 
 
@@ -181,8 +196,7 @@ app.MainController.prototype.setMap_ = function() {
       new ol.control.Zoom({zoomInLabel: '\ue032', zoomOutLabel: '\ue033'}),
       new ol.control.ZoomToExtent({label: '\ue01b',
         extent: this.defaultExtent_}),
-      new ol.control.FullScreen({label: '\ue01c', labelActive: '\ue02c'}),
-      new app.LocationControl({label: '\ue800'})
+      new ol.control.FullScreen({label: '\ue01c', labelActive: '\ue02c'})
     ],
     view: new ol.View({
       maxZoom: 19,

--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -14,6 +14,8 @@ goog.require('app.ExclusionManager');
 goog.require('app.LayerOpacityManager');
 goog.require('app.LocationControl');
 goog.require('app.Themes');
+goog.require('app.VectorOverlay');
+goog.require('app.VectorOverlayMgr');
 goog.require('goog.object');
 goog.require('ngeo.GetBrowserLanguage');
 goog.require('ngeo.SyncArrays');
@@ -38,6 +40,7 @@ goog.require('ol.tilegrid.WMTS');
  * @param {app.LayerOpacityManager} appLayerOpacityManager Layer opacity
  *     manager.
  * @param {app.Themes} appThemes Themes service.
+ * @param {app.VectorOverlayMgr} appVectorOverlayMgr Vector overlay manager.
  * @param {Object.<string, string>} langUrls URLs to translation files.
  * @param {Array.<number>} maxExtent Constraining extent.
  * @param {Array.<number>} defaultExtent Default geographical extent.
@@ -47,8 +50,8 @@ goog.require('ol.tilegrid.WMTS');
  * @ngInject
  */
 app.MainController = function($scope, ngeoGetBrowserLanguage, gettextCatalog,
-    appExclusionManager, appLayerOpacityManager, appThemes, langUrls,
-    maxExtent, defaultExtent, ngeoSyncArrays) {
+    appExclusionManager, appLayerOpacityManager, appThemes, appVectorOverlayMgr,
+    langUrls, maxExtent, defaultExtent, ngeoSyncArrays) {
 
   /**
    * @type {app.Themes}
@@ -160,6 +163,7 @@ app.MainController = function($scope, ngeoGetBrowserLanguage, gettextCatalog,
 
   appExclusionManager.init(this.map_);
   appLayerOpacityManager.init(this.map_);
+  appVectorOverlayMgr.init(this.map_);
 
   this.manageUserRoleChange_($scope);
 

--- a/geoportailv3/static/js/vectoroverlay.js
+++ b/geoportailv3/static/js/vectoroverlay.js
@@ -1,0 +1,216 @@
+/**
+ * @fileoverview This file provides a service that wraps an "unmanaged" vector
+ * layer, used as a shared vector layer accross the application.
+ */
+goog.provide('app.VectorOverlay');
+goog.provide('app.VectorOverlayMgr');
+
+goog.require('app');
+goog.require('goog.object');
+goog.require('ol.Feature');
+goog.require('ol.layer.Vector');
+goog.require('ol.source.Vector');
+goog.require('ol.style.Style');
+goog.require('ol.style.StyleFunction');
+
+
+/**
+ * @typedef {{
+ *  styleFunction: ol.style.StyleFunction,
+ *  features: Object.<string, ol.Feature>
+ * }}
+ */
+app.VectorOverlayGroup;
+
+
+
+/**
+ * @constructor
+ */
+app.VectorOverlayMgr = function() {
+
+  /**
+   * @type {Object.<string, number>}
+   * @private
+   */
+  this.featureUidToGroupIndex_ = {};
+
+  /**
+   * @type {Array.<app.VectorOverlayGroup>}
+   * @private
+   */
+  this.groups_ = [];
+
+  /**
+   * @type {ol.source.Vector}
+   * @private
+   */
+  this.source_ = new ol.source.Vector();
+
+  /**
+   * @type {ol.layer.Vector}
+   * @private
+   */
+  this.layer_ = new ol.layer.Vector({
+    source: this.source_,
+    style: goog.bind(this.styleFunction_, this),
+    useSpatialgroupIndex: false
+  });
+
+};
+
+
+/**
+ * @param {ol.Feature} feature The feature to add.
+ * @param {number} groupIndex The group groupIndex.
+ * @protected
+ */
+app.VectorOverlayMgr.prototype.addFeature = function(feature, groupIndex) {
+  goog.asserts.assert(groupIndex >= 0);
+  goog.asserts.assert(groupIndex < this.groups_.length);
+  var featureUid = goog.getUid(feature).toString();
+  this.featureUidToGroupIndex_[featureUid] = groupIndex;
+  this.groups_[groupIndex].features[featureUid] = feature;
+  this.source_.addFeature(feature);
+};
+
+
+/**
+ * @param {ol.Feature} feature The feature to add.
+ * @param {number} groupIndex The group groupIndex.
+ * @protected
+ */
+app.VectorOverlayMgr.prototype.removeFeature = function(feature, groupIndex) {
+  goog.asserts.assert(groupIndex >= 0);
+  goog.asserts.assert(groupIndex < this.groups_.length);
+  var featureUid = goog.getUid(feature).toString();
+  delete this.featureUidToGroupIndex_[featureUid];
+  delete this.groups_[groupIndex].features[featureUid];
+  this.source_.removeFeature(feature);
+};
+
+
+/**
+ * @param {number} groupIndex The group groupIndex.
+ * @protected
+ */
+app.VectorOverlayMgr.prototype.clear = function(groupIndex) {
+  goog.asserts.assert(groupIndex >= 0);
+  goog.asserts.assert(groupIndex < this.groups_.length);
+  var group = this.groups_[groupIndex];
+  for (var featureUid in group.features) {
+    this.removeFeature(group.features[featureUid], groupIndex);
+  }
+  goog.asserts.assert(goog.object.isEmpty(group.features));
+};
+
+
+/**
+ * @return {app.VectorOverlay} Vector overlay.
+ */
+app.VectorOverlayMgr.prototype.getVectorOverlay = function() {
+  var groupIndex = this.groups_.length;
+  this.groups_.push({
+    styleFunction: ol.style.defaultStyleFunction,
+    features: {}
+  });
+  return new app.VectorOverlay(this, groupIndex);
+};
+
+
+/**
+ * @param {ol.Map} map Map.
+ */
+app.VectorOverlayMgr.prototype.init = function(map) {
+  this.layer_.setMap(map);
+};
+
+
+/**
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction} style
+ * Style.
+ * @param {number} groupIndex Group index.
+ * @protected
+ */
+app.VectorOverlayMgr.prototype.setStyle = function(style, groupIndex) {
+  goog.asserts.assert(groupIndex >= 0);
+  goog.asserts.assert(groupIndex < this.groups_.length);
+  this.groups_[groupIndex].styleFunction = goog.isNull(style) ?
+      ol.style.defaultStyleFunction : ol.style.createStyleFunction(style);
+};
+
+
+/**
+ * @param {ol.Feature} feature Feature.
+ * @param {number} resolution Resolution.
+ * @return {Array.<ol.style.Style>} Styles.
+ * @private
+ */
+app.VectorOverlayMgr.prototype.styleFunction_ = function(feature, resolution) {
+  var featureUid = goog.getUid(feature).toString();
+  goog.asserts.assert(featureUid in this.featureUidToGroupIndex_);
+  var groupIndex = this.featureUidToGroupIndex_[featureUid];
+  var group = this.groups_[groupIndex];
+  return group.styleFunction(feature, resolution);
+};
+
+
+
+/**
+ * @constructor
+ * @param {app.VectorOverlayMgr} manager The vector overlay manager.
+ * @param {number} index This vector overlay's index.
+ */
+app.VectorOverlay = function(manager, index) {
+
+  /**
+   * @type {app.VectorOverlayMgr}
+   * @private
+   */
+  this.manager_ = manager;
+
+  /**
+   * @type {number}
+   * @private
+   */
+  this.index_ = index;
+};
+
+
+/**
+ * Add a feature to the vector overlay.
+ * @param {ol.Feature} feature The feature to add.
+ */
+app.VectorOverlay.prototype.addFeature = function(feature) {
+  this.manager_.addFeature(feature, this.index_);
+};
+
+
+/**
+ * Remove a feature from the vector overlay.
+ * @param {ol.Feature} feature The feature to add.
+ */
+app.VectorOverlay.prototype.removeFeature = function(feature) {
+  this.manager_.removeFeature(feature, this.index_);
+};
+
+
+/**
+ * Remove all the features from the vector overlay.
+ */
+app.VectorOverlay.prototype.clear = function() {
+  this.manager_.clear(this.index_);
+};
+
+
+/**
+ * Set a style for the vector overlay.
+ * @param {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction} style
+ * Style.
+ */
+app.VectorOverlay.prototype.setStyle = function(style) {
+  this.manager_.setStyle(style, this.index_);
+};
+
+
+app.module.service('appVectorOverlayMgr', app.VectorOverlayMgr);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "less": "~1.7.5",
     "ngeo": "camptocamp/ngeo#master",
     "nomnom": "~1.6.2",
-    "openlayers": "openlayers/ol3#v3.6.0",
+    "openlayers": "openlayers/ol3#master",
     "proj4": "2.3.3",
     "phantomjs": "~1.9.7-5",
     "typeahead.js": "~0.10.5",


### PR DESCRIPTION
This PR removes the `FeatureOverlay`s and adds an `appVectorOverlay` service that components can use in place a `FeatureOverlay`.

The use of `appVectorOverlay` in a component is as follows:

```js
var index = appVectorOverlay.getIndex();

appVectorOverlay.addFeature(feature, index);
appVectorOverlay.removeFeature(feature, index);
appVectorOverlay.clear(index);
```

The `index` returned by `getIndex` can be seen as handle or a cookie that you need to use in subsequent operations.

This needs reviews and testing.

Please at least review the changes to the components you created in the first place.