### PR TITLE
Vector overlay print support

### DIFF
--- a/geoportailv3/static/js/profile/profiledirective.js
+++ b/geoportailv3/static/js/profile/profiledirective.js
@@ -105,7 +105,7 @@ app.ProfileController = function($scope, appVectorOverlayMgr) {
       new ol.style.Style({
         image: new ol.style.Circle({
           radius: 3,
-          fill: new ol.style.Fill({color: 'white'})
+          fill: new ol.style.Fill({color: '#ffffff'})
         })
       }));
 

--- a/geoportailv3/static/js/query/querydirective.js
+++ b/geoportailv3/static/js/query/querydirective.js
@@ -137,7 +137,7 @@ app.QueryController = function($timeout, $scope, $http,
     }),
     new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color: 'white',
+        color: '#ffffff',
         width: 5
       })
     }),

--- a/geoportailv3/static/js/vectoroverlay.js
+++ b/geoportailv3/static/js/vectoroverlay.js
@@ -106,6 +106,14 @@ app.VectorOverlayMgr.prototype.clear = function(groupIndex) {
 
 
 /**
+ * @return {ol.layer.Vector} The vector layer used internally.
+ */
+app.VectorOverlayMgr.prototype.getLayer = function() {
+  return this.layer_;
+};
+
+
+/**
  * @return {app.VectorOverlay} Vector overlay.
  */
 app.VectorOverlayMgr.prototype.getVectorOverlay = function() {


### PR DESCRIPTION
With this PR the vector layer used by vector overlays is printed.

Fixes #595.

Requires https://github.com/camptocamp/ngeo/pull/252.