### PR TITLE
Remove unrequired featureOverlayItemExists property

### DIFF
--- a/geoportailv3/static/js/locationinfo/locationinfo.html
+++ b/geoportailv3/static/js/locationinfo/locationinfo.html
@@ -1,5 +1,5 @@
 <div class="container-fluid" ng-show="ctrl.appSelector == 'locationinfo'">
-  <div class="row" ng-show="ctrl.featureOverlayItemExists">
+  <div class="row">
     <div class="col-xs-8">
       <h3 translate>Short Url</h3>
       <input onclick="this.select();" type="text" class="form-control" name="shorturl" ng-model="ctrl.url" readonly="readonly" />
@@ -8,7 +8,7 @@
       <img class="img-responsive" style="margin-top: 22px;" src="{{ ctrl.qrUrl }}"></img>
     </div>
   </div>
-  <div class="row" ng-show="ctrl.featureOverlayItemExists">
+  <div class="row">
     <div class="col-xs-12">
       <h3 translate>Location Coordinates</h3>
       <table class="table-condensed">

--- a/geoportailv3/static/js/locationinfo/locationinfodirective.js
+++ b/geoportailv3/static/js/locationinfo/locationinfodirective.js
@@ -94,11 +94,6 @@ app.LocationinfoController =
         })];
       });
 
-  /**
-   * @type {boolean}
-   */
-  this['featureOverlayItemExists'] = false;
-
   $scope.$watch(goog.bind(function() {
     return this['appSelector'];
   }, this), goog.bind(function(newVal) {
@@ -113,11 +108,9 @@ app.LocationinfoController =
     if (newVal === false) {
       this.stateManager_.updateState({'crosshair': false});
       this['appSelector'] = undefined;
-      this['featureOverlayItemExists'] = false;
       this.vectorOverlay_.clear();
     } else if (newVal === true) {
       this.stateManager_.updateState({'crosshair': true});
-      this['featureOverlayItemExists'] = true;
     }
   }, this));
 
@@ -294,7 +287,6 @@ app.LocationinfoController.prototype.showInfoPane_ =
       (new ol.Feature(new ol.geom.Point(clickCoordinate)));
   this.vectorOverlay_.clear();
   this.vectorOverlay_.addFeature(feature);
-  this['featureOverlayItemExists'] = true;
   this.getElevation_(clickCoordinate).then(goog.bind(
       function(elevation) {
         this['elevation'] = elevation;


### PR DESCRIPTION
@petzlux Can you please give this a review?
In my opinion, the `featureOverlayItemExists` isn't really useful. To me, ```appSelector == 'locationinfo'``` already does the job.