### PR TITLE
Select the smallest print scale if no optimal

### DIFF
--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -582,9 +582,11 @@ app.PrintController.prototype.useOptimalScale_ = function() {
   var idx = this['layouts'].indexOf(this['layout']);
   goog.asserts.assert(idx >= 0);
 
-  this['scale'] = this.printUtils_.getOptimalScale(mapSize,
+  var scale = this.printUtils_.getOptimalScale(mapSize,
       viewCenterResolution, app.PrintController.MAP_SIZES_[idx],
       this['scales']);
+
+  this['scale'] = scale != -1 ? scale : this['scales'][0];
 };
 
 


### PR DESCRIPTION
With this commit the smallest print scale is selected if there is no optimal scale for the current map resolution. This fixes a bug when an "infinite" scale was used.

Fixes #665.

Requires https://github.com/camptocamp/ngeo/pull/258.