### PR TITLE
go back to 96 dpi resolution in print 

### DIFF
--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -294,7 +294,7 @@ app.PrintController.MAP_SIZES_ = [
  * @type {number}
  * @private
  */
-app.PrintController.DPI_ = 300;
+app.PrintController.DPI_ = 96;
 
 
 /**


### PR DESCRIPTION
to avoid symbol scaling problems. a better solution will be implemented later on