### PR TITLE
Fix vector printing bugs

### DIFF
--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -442,7 +442,9 @@ app.PrintController.prototype.print = function() {
         var resolution = map.getView().getResolution();
         goog.asserts.assert(goog.isDef(resolution));
         this.print_.encodeLayer(layers, this.vectorOverlayLayer_, resolution);
-        spec.attributes.map.layers.unshift(layers[0]);
+        if (layers.length > 0) {
+          spec.attributes.map.layers.unshift(layers[0]);
+        }
 
         // create print report
         this.print_.createReport(spec, /** @type {angular.$http.Config} */ ({


### PR DESCRIPTION
This PR, together with https://github.com/camptocamp/ngeo/pull/261, fix the following vector printing bug:

* Point features displayed by the search component are not printed.
* MapFish Print raises an exception when the vector layer is empty.

Fixes #663.