### PR TITLE
Translations - update of tools and plural translations

### DIFF
--- a/geoportailv3/locale/de/LC_MESSAGES/geoportailv3-client.po
+++ b/geoportailv3/locale/de/LC_MESSAGES/geoportailv3-client.po
@@ -1,11 +1,12 @@
 # 
 # Translators:
 # Andre aDonno <andrea.donno@me.com>, 2015
+# Francis Kaell <francis.kaell@act.etat.lu>, 2015
 # patrick weber <pweber@spatialbit.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: portail\n"
-"PO-Revision-Date: 2015-07-08 14:07+0000\n"
+"PO-Revision-Date: 2015-07-13 06:43+0000\n"
 "Last-Translator: patrick weber <pweber@spatialbit.com>\n"
 "Language-Team: German (http://www.transifex.com/p/geoportailv3-lu/language/de/)\n"
 "MIME-Version: 1.0\n"
@@ -14,381 +15,406 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:91
 msgid "+ Add layers"
 msgstr "+ Layer hinzufügen"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/static/js/share/sharedirective.js:110
+msgid "- link from geoportail.lu"
+msgstr "Karte aus geoportal.lu"
+
+#: geoportailv3/templates/index.html:124
 msgid ""
 "A <em>right click</em> (tap and hold on mobile) will display information "
 "about the current location."
-msgstr ""
+msgstr "Durch <em>Rechtsklick</em> (tippen und halten auf Mobil) werden Informationen über den aktuellen Standort angezeigt"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:127
 msgid ""
 "A <em>short click</em> (tap on mobile) on a map feature will select the "
 "feature and show more information."
 msgstr ""
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:165
 msgid "A0 landscape"
 msgstr "A0 quer"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:164
 msgid "A0 portrait"
 msgstr "A0 hoch"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:163
 msgid "A1 landscape"
 msgstr "A1 quer"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:162
 msgid "A1 portrait"
 msgstr "A1 hoch"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:161
 msgid "A2 landscape"
 msgstr "A2 quer"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:160
 msgid "A2 portrait"
 msgstr "A2 hoch"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:159
 msgid "A3 landscape"
 msgstr "A3 quer"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:158
 msgid "A3 portrait"
 msgstr "A3 hoch"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:157
 msgid "A4 landscape"
 msgstr "A4 quer"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:156
 msgid "A4 portrait"
 msgstr "A4 hoch "
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:45
 msgid "Abort"
 msgstr "Abbrechen"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:359
 msgid "Addresses"
 msgstr "Adressen"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:11
 msgid "Azimut"
 msgstr "Azimut"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:344
 msgid "Background"
 msgstr "Hintergrund"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:333
 msgid "Background Layers"
 msgstr "Hintergrund Karten"
 
-#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html
-msgid "Background layer:"
-msgstr "Hinterground Karte:"
+#: geoportailv3/static/js/exclusionmanagerservice.js:126
+msgid ""
+"Background has been deactivated because the layer {{layer}} cannot be "
+"displayed on top of it."
+msgstr "Die Hintergrundkarte wurde ausgeschaltet weil sie nicht mit dem Layer {{layer}} angezeigt werden kann.  "
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html:2
+msgid "Background layer:"
+msgstr "Hintergrund Karte:"
+
+#: geoportailv3/templates/index.html:82
 msgid "Catalog"
 msgstr "Katalog"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:4
 msgid "Changer"
 msgstr "Wechseln"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:136
 msgid ""
 "Click to continue drawing the line<br>Double-click or click last point to "
 "finish"
 msgstr "Klicken Sie um mit dem zeichnen der Linie fortzufahren <br> Doppelklick zum Abschließen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:174
 msgid ""
 "Click to continue drawing the polygon<br>Double-click or click last point to"
 " finish"
 msgstr "Klicken Sie um mit dem zeichnen des Polygons fortzufahren <br> Doppelklick zum Abschließen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:193
 msgid "Click to finish"
 msgstr "Klicken Sie zum Abschließen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:173
 msgid "Click to start drawing area"
-msgstr "Klicken Sie um mit dem zeichnen der Fläche anzufangen"
+msgstr "Klicken Sie um mit dem messen der Fläche anzufangen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:192
 msgid "Click to start drawing azimut"
-msgstr "Klicken Sie um mit dem zeichnen des Azimuts anzufangen"
+msgstr "Klicken Sie um mit dem messen des Azimuts anzufangen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:152
 msgid "Click to start drawing length"
-msgstr "Klicken Sie um mit dem zeichnen der Länge anzufangen"
+msgstr "Klicken Sie um mit dem messen der Länge anzufangen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:135
 msgid "Click to start drawing profile"
-msgstr "Klicken Sie um mit dem zeichnen des Profils anzufangen"
+msgstr "Klicken Sie um mit dem messen des Profils anzufangen"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/urplang.html:7
+msgid "Cliquez dans l'image pour agrandir"
+msgstr ""
+
+#: geoportailv3/static/js/query/parcels.html:10
 msgid "Commander un extrait"
 msgstr "Einen Kadasterauszug bestellen"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:4
 msgid "Commune"
 msgstr "Gemeinde"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:18
 msgid "Contact"
 msgstr "Kontakt"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:7
 msgid "Contenance"
 msgstr "Kapazität"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:143
 msgid "Couches"
 msgstr "Layers"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:13
 msgid "Create a new user account"
 msgstr "Ein neues Benutzerkonto erstellen"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:9
 msgid "Dernier mesurage"
 msgstr "Letze Messung"
 
-#: geoportailv3/static/js/layerinfo/popup.html
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/layerinfo/popup.html:9
+#: geoportailv3/static/js/query/mymaps.html:6
 msgid "Description"
 msgstr "Beschreibung"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:159
 msgid "Dessin"
 msgstr "Zeichnen"
 
-#: geoportailv3/static/js/profile/profile.html
+#: geoportailv3/static/js/profile/profile.html:5
 msgid "Draw a line on the map to display an elevation profile."
-msgstr "Zeichne eine Linie auf der Karte um ein Höhenprofil zu erhalten."
+msgstr "Zeichneen Sie eine Linie auf der Karte um ein Höhenprofil zu erhalten."
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:19
 msgid "Elevation"
 msgstr "Höhe"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:13
 msgid "Email"
 msgstr "Email"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:4
 msgid "Facebook"
 msgstr "Facebook"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:10
 msgid "Google Plus"
 msgstr "Google Plus"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:12
 msgid "I lost my password"
 msgstr "Ich habe mein Passwort vergessen"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:171
 msgid "Imprimer"
 msgstr "Drucken"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:149
 msgid "Infos"
 msgstr "Infos"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:11
 msgid "Invalid username or password"
 msgstr "Ungültiger Benutzername oder Passwort"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:17
 msgid "Keywords"
 msgstr "Schlüsselwörter"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:304
 msgid "Layers"
 msgstr "Layers"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:35
 msgid "Legend"
 msgstr "Legende"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:3
 msgid "Length"
 msgstr "Länge"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:153
 msgid "Lien 1"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:154
 msgid "Lien 2"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:155
 msgid "Lien 3"
 msgstr ""
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:27
 msgid "Link to the metadata"
 msgstr "Link zu den Metadaten"
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:13
 msgid "Location Coordinates"
 msgstr "Standortkoordinaten"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:4
 msgid "Login"
 msgstr "Einloggen"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:23
 msgid "Logout"
 msgstr "Abmelden"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:7
 msgid "Longeueur"
 msgstr "Länge"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:146
 msgid "Mes Cartes"
 msgstr "My Maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:163
 msgid "Mesurer"
 msgstr "Messen"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:2
+#: geoportailv3/static/js/authentication/authentication.html:22
 msgid "My account"
 msgstr "Mein Konto"
 
-#: geoportailv3/static/js/elevationservice.js
+#: geoportailv3/static/js/elevationservice.js:50
 msgid "N/A"
 msgstr ""
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:8
 msgid "Name"
 msgstr "Name"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:8
 msgid "Nature"
 msgstr "Natur"
 
-#: geoportailv3/static/js/layermanager/layermanager.html
+#: geoportailv3/static/js/layermanager/layermanager.html:1
 msgid "No layer selected"
 msgstr "Kein Layer ausgewählt"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:5
 msgid "Nom"
 msgstr "Name"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:6
 msgid "Numero cadastral"
 msgstr "Kadaster Nummer"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:176
 msgid "Partager"
 msgstr "Teilen"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:8
 msgid "Password"
 msgstr "Passwort"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:15
 msgid "Profile"
 msgstr "Profil"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:8
 msgid "Rating"
 msgstr "Wertung"
 
-#: geoportailv3/static/js/search/search.html
+#: geoportailv3/static/js/search/search.html:6
 msgid "Recherche adresse, parcelles, couches ..."
 msgstr "Suche Adressen, Parzellen, Layers ..."
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:16
 msgid "Revision date"
 msgstr "Überarbeitungsdatum"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:5
 msgid "Section"
 msgstr "Sektion"
 
-#: geoportailv3/static/js/share/shorturl.html
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:4
+#: geoportailv3/static/js/share/shorturl.html:4
 msgid "Short Url"
-msgstr "Kurze Url"
+msgstr "Url"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:9
 msgid "Submit"
 msgstr "Einloggen"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:7
 msgid "Surface"
 msgstr "Fläche"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/exclusionmanagerservice.js:139
+msgid ""
+"The layer <b>{{layersToRemove}}</b> has been removed because it cannot be "
+"displayed while the layer <b>{{layer}}</b> is displayed"
+msgid_plural ""
+"The layers <b>{{layersToRemove}}</b> have been removed because they cannot "
+"be displayed while the layer <b>{{layer}}</b> is displayed"
+msgstr[0] "Der Layer <b>{{layersToRemove}}</b> wurde entfernt, weil er nicht mit dem Layer <b>{{layer}}</b> angezeigt werden kann"
+msgstr[1] "Die Layer <b>{{layersToRemove}}</b> wurden entfernt, weil sie nicht mit dem Layer <b>{{layer}}</b> angezeigt werden können"
+
+#: geoportailv3/static/js/layerinfo/popup.html:38
 msgid "The legend is not available for this layer"
 msgstr "Keine Legende für diesen Layer"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:34
 msgid "The metadata is right now not available"
 msgstr "Die Metadaten sind momentan nicht erhältlich"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:2
 msgid "Theme"
 msgstr "Thema"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:6
 msgid "Title"
 msgstr "Titel"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:7
 msgid "Twitter"
 msgstr "Twitter"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:7
 msgid "Username"
 msgstr "Benutzername"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:13
 msgid "With legend"
 msgstr "Mit Legende"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:108
 msgid "infos"
 msgstr "Informationen"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:42
 msgid "lang"
 msgstr "Sprache"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:69
 msgid "layers"
 msgstr "Layers"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:11
 msgid "map_title"
 msgstr "Karten Titel"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:77
 msgid "my_layers"
 msgstr "Meine Layers"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:102
 msgid "my_maps"
 msgstr "My maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:34
 msgid "search"
 msgstr "Suchen"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:36
 msgid "user"
 msgstr "Benutzer"
 
@@ -418,7 +444,7 @@ msgstr "Raumordnung"
 
 #: theme.107 lu_ext_wms.292
 msgid "nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: theme.108
 msgid "go"
@@ -474,7 +500,7 @@ msgstr "Wasser"
 
 #: theme.121
 msgid "remich"
-msgstr "Flächennutzungsplan Remich"
+msgstr "Remich"
 
 #: theme.122
 msgid "test"
@@ -490,11 +516,11 @@ msgstr "Landwirtschaft"
 
 #: theme.125
 msgid "preizerdaul"
-msgstr ""
+msgstr "Preizerdaul"
 
 #: theme.126
 msgid "wellenstein"
-msgstr "wellenstein_link_title"
+msgstr "Wellenstein"
 
 #: theme.127
 msgid "at_mobile"
@@ -502,15 +528,15 @@ msgstr "Raumplanung"
 
 #: theme.128
 msgid "eau"
-msgstr "Messen"
+msgstr "Wasser"
 
 #: theme.129
 msgid "lintgen"
-msgstr ""
+msgstr "Lintgen"
 
 #: theme.130
 msgid "lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: theme.131
 msgid "municipalities"
@@ -522,7 +548,7 @@ msgstr ""
 
 #: theme.133 lu_int_wms.465
 msgid "olos"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: group.134
 msgid "emwelt_biotop_kadaster_mobile"
@@ -530,7 +556,7 @@ msgstr "Offenland-Biotopkataster"
 
 #: lu_int_wms.135
 msgid "ac_preizerdaul_ortho_2009"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: lu_int_wms.136
 msgid "asta_esp_lisiere"
@@ -562,7 +588,7 @@ msgstr "Offenland-Biotopkadaster: Streuobstwiesen"
 
 #: group.143
 msgid "group_nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: group.144
 msgid "env_natura2000"
@@ -670,7 +696,7 @@ msgstr "Schutzgebiete"
 
 #: group.170
 msgid "mittal_group"
-msgstr "Raumordnung"
+msgstr "Parzellen der Mittal Gruppe"
 
 #: group.171
 msgid "presidence_restos"
@@ -926,7 +952,7 @@ msgstr "Luftbilder von 1951 (1:25k)"
 
 #: lu_int_wms.234
 msgid "mittal"
-msgstr ""
+msgstr "Parzellen der Mittal Gruppe"
 
 #: l_wmts.235
 msgid "ortho_2007"
@@ -1146,7 +1172,7 @@ msgstr "Höhenlinien 10m"
 
 #: group.290
 msgid "group_ac_preizerdaul_pag"
-msgstr ""
+msgstr "FNP Preizerdaul"
 
 #: l_wmts.291
 msgid "wg_hangneigung_"
@@ -1450,7 +1476,7 @@ msgstr "Luxemburg zu Pferd"
 
 #: lu_int_wms.367
 msgid "ac_preizerdaul_ortho"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: l_wmts.368
 msgid "emwelt_biotop_kadaster_f"
@@ -1470,7 +1496,7 @@ msgstr "Habitate Natura 2000"
 
 #: lu_int_wms.372
 msgid "natur_an_emwelt_terrains"
-msgstr ""
+msgstr "Natur & Ëmwelt"
 
 #: lu_int_wms.373
 msgid "mobiliteit_bikeshare"
@@ -1530,11 +1556,11 @@ msgstr "Naturschutzgebiete (DIG)"
 
 #: lu_ext_wms.387
 msgid "Merovingien"
-msgstr ""
+msgstr "Merovingien"
 
 #: group.388
 msgid "Archeo"
-msgstr ""
+msgstr "Archéologie"
 
 #: lu_int_wms.389
 msgid "anf_peuplements_semenciers"
@@ -1554,7 +1580,7 @@ msgstr "Waldnaturschutzgebiete"
 
 #: lu_ext_wms.393
 msgid "Prehistoire"
-msgstr ""
+msgstr "Préhistoire"
 
 #: lu_ext_wms.394
 msgid "Moyen Age"
@@ -1562,19 +1588,19 @@ msgstr ""
 
 #: lu_ext_wms.395
 msgid "Temps modernes"
-msgstr ""
+msgstr "Temps modernes"
 
 #: lu_ext_wms.396
 msgid "Epoque indefinie"
-msgstr ""
+msgstr "Epoque indéfinie"
 
 #: lu_ext_wms.397
 msgid "Protohistoire"
-msgstr ""
+msgstr "Protohistoire"
 
 #: lu_ext_wms.398
 msgid "Gallo-Romain"
-msgstr ""
+msgstr "Gallo-Romain"
 
 #: lu_int_wms.399
 msgid "anf_arbres_remarquables"
@@ -1734,7 +1760,7 @@ msgstr "PRE"
 
 #: lu_int_wms.438
 msgid "pag_lintgen_layer"
-msgstr ""
+msgstr "Flächennutzungsplan der Gemeinde Lintgen"
 
 #: group.439
 msgid "eau_new_Projekt_TIMIS_(usage_interne)"
@@ -1742,7 +1768,7 @@ msgstr "Projekt TIMIS"
 
 #: group.440
 msgid "group_lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: lu_int_wms.441
 msgid "at_pst3"
@@ -1786,7 +1812,7 @@ msgstr "Chemischer Zustand der WK 2009"
 
 #: lu_int_wms.451
 msgid "env_corridors"
-msgstr ""
+msgstr "Corridors"
 
 #: lu_int_wms.452
 msgid "env_iba"
@@ -1838,11 +1864,11 @@ msgstr "Katasterparzellen"
 
 #: group.464
 msgid "olos_group"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: lu_int_wms.466
 msgid "topo_decoupage_5000_ed2015"
-msgstr ""
+msgstr "Blattschnitt topographischer Plan 1:5000 Ausgabe 2015"
 
 #: group.467
 msgid "eau_new_Risikobeurteilung_2021"
@@ -1998,11 +2024,11 @@ msgstr "Natur & Ausflüge"
 
 #: lu_int_wms.505
 msgid "lenoz_lmg"
-msgstr ""
+msgstr "Lebensmittelgeschäfte"
 
 #: lu_int_wms.506
 msgid "lenoz_ecoles_old"
-msgstr ""
+msgstr "Schulen"
 
 #: lu_int_wms.507
 msgid "ont_poi_5"
@@ -2010,7 +2036,7 @@ msgstr "Sport & Freizeit"
 
 #: lu_int_wms.508
 msgid "lenoz_creches"
-msgstr ""
+msgstr "Kinderkrippen"
 
 #: lu_int_wms.509
 msgid "ont_poi_7"
@@ -2042,15 +2068,15 @@ msgstr "«Pickup»-Stationen"
 
 #: lu_int_wms.516
 msgid "asta_flik_parcels_2015_prof"
-msgstr ""
+msgstr "FLIK Parzellen der ASTA Version 2015"
 
 #: lu_int_wms.517
 msgid "lenoz_Banken"
-msgstr ""
+msgstr "Banken"
 
 #: lu_int_wms.518
 msgid "lenoz_Tankstelle"
-msgstr ""
+msgstr "Tankstellen"
 
 #: group.519
 msgid "wrrl_intern_hs"
@@ -2066,19 +2092,19 @@ msgstr "Ökologisch wertvolle Flächen "
 
 #: lu_int_wms.522
 msgid "lenoz_Ärzte"
-msgstr ""
+msgstr "Ärzte"
 
 #: lu_int_wms.523
 msgid "lenoz_Post"
-msgstr ""
+msgstr "Post"
 
 #: lu_int_wms.524
 msgid "lenoz_Lycees"
-msgstr ""
+msgstr "Gymnasien"
 
 #: lu_int_wms.525
 msgid "lenoz_Restaurants"
-msgstr ""
+msgstr "Restaurants"
 
 #: lu_int_wms.526
 msgid "ont_poi"

--- a/geoportailv3/locale/en/LC_MESSAGES/geoportailv3-client.po
+++ b/geoportailv3/locale/en/LC_MESSAGES/geoportailv3-client.po
@@ -2,11 +2,12 @@
 # Translators:
 # Andre aDonno <andrea.donno@me.com>, 2015
 # eRenaud Michaëlis <renaud.michaelis@act.etat.lu>, 2015
+# Francis Kaell <francis.kaell@act.etat.lu>, 2015
 # patrick weber <pweber@spatialbit.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: portail\n"
-"PO-Revision-Date: 2015-07-08 14:18+0000\n"
+"PO-Revision-Date: 2015-07-13 06:43+0000\n"
 "Last-Translator: patrick weber <pweber@spatialbit.com>\n"
 "Language-Team: English (http://www.transifex.com/p/geoportailv3-lu/language/en/)\n"
 "MIME-Version: 1.0\n"
@@ -15,381 +16,406 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:91
 msgid "+ Add layers"
 msgstr "+ Add layers"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/static/js/share/sharedirective.js:110
+msgid "- link from geoportail.lu"
+msgstr "Map from geoportal.lu"
+
+#: geoportailv3/templates/index.html:124
 msgid ""
 "A <em>right click</em> (tap and hold on mobile) will display information "
 "about the current location."
-msgstr ""
+msgstr "A <em>right click</em> (tap and hold on mobile) will display information about the current location."
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:127
 msgid ""
 "A <em>short click</em> (tap on mobile) on a map feature will select the "
 "feature and show more information."
-msgstr ""
+msgstr "A <em>short click</em> (tap on mobile) on a map feature will select the feature and show more information."
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:165
 msgid "A0 landscape"
 msgstr "A0 landscape"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:164
 msgid "A0 portrait"
 msgstr "A0 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:163
 msgid "A1 landscape"
 msgstr "A1 landscape"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:162
 msgid "A1 portrait"
 msgstr "A1 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:161
 msgid "A2 landscape"
 msgstr "A2 landscape"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:160
 msgid "A2 portrait"
 msgstr "A2 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:159
 msgid "A3 landscape"
 msgstr "A3 landscape"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:158
 msgid "A3 portrait"
 msgstr "A3 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:157
 msgid "A4 landscape"
 msgstr "A4 landscape"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:156
 msgid "A4 portrait"
 msgstr "A4 portrait"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:45
 msgid "Abort"
 msgstr "Abort"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:359
 msgid "Addresses"
 msgstr "Addresses"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:11
 msgid "Azimut"
 msgstr "Azimut"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:344
 msgid "Background"
 msgstr "Background"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:333
 msgid "Background Layers"
 msgstr "Background Layers"
 
-#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html
+#: geoportailv3/static/js/exclusionmanagerservice.js:126
+msgid ""
+"Background has been deactivated because the layer {{layer}} cannot be "
+"displayed on top of it."
+msgstr "Background has been deactivated because the layer {{layer}} cannot be displayed on top of it."
+
+#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html:2
 msgid "Background layer:"
 msgstr "Background layer"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:82
 msgid "Catalog"
 msgstr "Catalog"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:4
 msgid "Changer"
 msgstr "Change"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:136
 msgid ""
 "Click to continue drawing the line<br>Double-click or click last point to "
 "finish"
 msgstr "Click to continue drawing the line<br>Double-click to finish"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:174
 msgid ""
 "Click to continue drawing the polygon<br>Double-click or click last point to"
 " finish"
 msgstr "Click to continue drawing the polygon<br>Double-click to finish"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:193
 msgid "Click to finish"
 msgstr "Click to finish"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:173
 msgid "Click to start drawing area"
-msgstr "Click to start drawing area"
+msgstr "Click to start measuring an area"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:192
 msgid "Click to start drawing azimut"
-msgstr "Click to start drawing azimut"
+msgstr "Click to start measuring an azimut"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:152
 msgid "Click to start drawing length"
-msgstr "Click to start drawing length"
+msgstr "Click to start measuring a distance"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:135
 msgid "Click to start drawing profile"
-msgstr "Click to start drawing profile"
+msgstr "Click to start measuring a profile"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/urplang.html:7
+msgid "Cliquez dans l'image pour agrandir"
+msgstr ""
+
+#: geoportailv3/static/js/query/parcels.html:10
 msgid "Commander un extrait"
 msgstr "Order a cadastral extract"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:4
 msgid "Commune"
 msgstr "Commune"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:18
 msgid "Contact"
 msgstr "Contact"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:7
 msgid "Contenance"
 msgstr "capacity"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:143
 msgid "Couches"
 msgstr "Layers"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:13
 msgid "Create a new user account"
 msgstr "Create a new user account"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:9
 msgid "Dernier mesurage"
 msgstr "Last measurement"
 
-#: geoportailv3/static/js/layerinfo/popup.html
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/layerinfo/popup.html:9
+#: geoportailv3/static/js/query/mymaps.html:6
 msgid "Description"
 msgstr "Description"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:159
 msgid "Dessin"
 msgstr "Draw"
 
-#: geoportailv3/static/js/profile/profile.html
+#: geoportailv3/static/js/profile/profile.html:5
 msgid "Draw a line on the map to display an elevation profile."
 msgstr "Draw a line on the map to display an elevation profile."
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:19
 msgid "Elevation"
 msgstr "Elevation"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:13
 msgid "Email"
 msgstr "Email"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:4
 msgid "Facebook"
 msgstr "Facebook"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:10
 msgid "Google Plus"
 msgstr "Google Plus"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:12
 msgid "I lost my password"
 msgstr "I lost my password"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:171
 msgid "Imprimer"
 msgstr "Print"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:149
 msgid "Infos"
 msgstr "Infos"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:11
 msgid "Invalid username or password"
 msgstr "Invalid username or password"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:17
 msgid "Keywords"
 msgstr "Keywords"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:304
 msgid "Layers"
 msgstr "Layers"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:35
 msgid "Legend"
 msgstr "Legend"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:3
 msgid "Length"
 msgstr "Length"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:153
 msgid "Lien 1"
-msgstr "Link 1"
+msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:154
 msgid "Lien 2"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:155
 msgid "Lien 3"
 msgstr ""
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:27
 msgid "Link to the metadata"
 msgstr "Link to the metadata"
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:13
 msgid "Location Coordinates"
 msgstr ""
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:4
 msgid "Login"
 msgstr "Login"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:23
 msgid "Logout"
 msgstr "Logout"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:7
 msgid "Longeueur"
 msgstr "length"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:146
 msgid "Mes Cartes"
 msgstr "My Maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:163
 msgid "Mesurer"
 msgstr "Measure"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:2
+#: geoportailv3/static/js/authentication/authentication.html:22
 msgid "My account"
 msgstr "My account"
 
-#: geoportailv3/static/js/elevationservice.js
+#: geoportailv3/static/js/elevationservice.js:50
 msgid "N/A"
 msgstr "N/A"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:8
 msgid "Name"
 msgstr "Name"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:8
 msgid "Nature"
 msgstr "Nature"
 
-#: geoportailv3/static/js/layermanager/layermanager.html
+#: geoportailv3/static/js/layermanager/layermanager.html:1
 msgid "No layer selected"
 msgstr "No layer selected"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:5
 msgid "Nom"
 msgstr "Name"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:6
 msgid "Numero cadastral"
 msgstr "Cadastral Number"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:176
 msgid "Partager"
 msgstr "Share"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:8
 msgid "Password"
 msgstr "Password"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:15
 msgid "Profile"
 msgstr "Profile"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:8
 msgid "Rating"
 msgstr "Rating"
 
-#: geoportailv3/static/js/search/search.html
+#: geoportailv3/static/js/search/search.html:6
 msgid "Recherche adresse, parcelles, couches ..."
 msgstr "Search addresses, parcels, layers ... "
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:16
 msgid "Revision date"
 msgstr "Revision Date"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:5
 msgid "Section"
 msgstr "Section"
 
-#: geoportailv3/static/js/share/shorturl.html
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:4
+#: geoportailv3/static/js/share/shorturl.html:4
 msgid "Short Url"
-msgstr "Short Url"
+msgstr "Url"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:9
 msgid "Submit"
 msgstr "Submit"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:7
 msgid "Surface"
 msgstr "Surface"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/exclusionmanagerservice.js:139
+msgid ""
+"The layer <b>{{layersToRemove}}</b> has been removed because it cannot be "
+"displayed while the layer <b>{{layer}}</b> is displayed"
+msgid_plural ""
+"The layers <b>{{layersToRemove}}</b> have been removed because they cannot "
+"be displayed while the layer <b>{{layer}}</b> is displayed"
+msgstr[0] ""
+msgstr[1] ""
+
+#: geoportailv3/static/js/layerinfo/popup.html:38
 msgid "The legend is not available for this layer"
 msgstr "The legend is not available for this layer"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:34
 msgid "The metadata is right now not available"
 msgstr "The metadata is right now not available"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:2
 msgid "Theme"
 msgstr "Theme"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:6
 msgid "Title"
 msgstr "Title"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:7
 msgid "Twitter"
 msgstr "Twitter"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:7
 msgid "Username"
 msgstr "Username"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:13
 msgid "With legend"
 msgstr "With legend"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:108
 msgid "infos"
 msgstr "infos"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:42
 msgid "lang"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:69
 msgid "layers"
 msgstr "Layers"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:11
 msgid "map_title"
 msgstr "Map Title"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:77
 msgid "my_layers"
 msgstr "My Layers"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:102
 msgid "my_maps"
 msgstr "My Maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:34
 msgid "search"
 msgstr "Search"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:36
 msgid "user"
 msgstr "User"
 
@@ -419,7 +445,7 @@ msgstr "Spatial planning"
 
 #: theme.107 lu_ext_wms.292
 msgid "nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: theme.108
 msgid "go"
@@ -475,7 +501,7 @@ msgstr "Water"
 
 #: theme.121
 msgid "remich"
-msgstr "Land Use Plan Remich"
+msgstr "Remich"
 
 #: theme.122
 msgid "test"
@@ -491,7 +517,7 @@ msgstr "Agriculture"
 
 #: theme.125
 msgid "preizerdaul"
-msgstr ""
+msgstr "Preizerdaul"
 
 #: theme.126
 msgid "wellenstein"
@@ -503,7 +529,7 @@ msgstr "Urban planning"
 
 #: theme.128
 msgid "eau"
-msgstr "Measure"
+msgstr "Water"
 
 #: theme.129
 msgid "lintgen"
@@ -511,7 +537,7 @@ msgstr ""
 
 #: theme.130
 msgid "lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: theme.131
 msgid "municipalities"
@@ -523,7 +549,7 @@ msgstr ""
 
 #: theme.133 lu_int_wms.465
 msgid "olos"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: group.134
 msgid "emwelt_biotop_kadaster_mobile"
@@ -531,7 +557,7 @@ msgstr "Biotope cadaster of the open landscapes"
 
 #: lu_int_wms.135
 msgid "ac_preizerdaul_ortho_2009"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: lu_int_wms.136
 msgid "asta_esp_lisiere"
@@ -563,7 +589,7 @@ msgstr "Biotope cadastre of the open landscapes: Orchards"
 
 #: group.143
 msgid "group_nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: group.144
 msgid "env_natura2000"
@@ -671,7 +697,7 @@ msgstr "Protected Areas"
 
 #: group.170
 msgid "mittal_group"
-msgstr "Spatial planning"
+msgstr "Parcels of the Mittal Group"
 
 #: group.171
 msgid "presidence_restos"
@@ -927,7 +953,7 @@ msgstr "Aerial images from 1951 (1:25k)"
 
 #: lu_int_wms.234
 msgid "mittal"
-msgstr ""
+msgstr "Parcels of the Mittal Group"
 
 #: l_wmts.235
 msgid "ortho_2007"
@@ -1147,7 +1173,7 @@ msgstr "Contour 10 m"
 
 #: group.290
 msgid "group_ac_preizerdaul_pag"
-msgstr ""
+msgstr "LUP Preizerdaul"
 
 #: l_wmts.291
 msgid "wg_hangneigung_"
@@ -1451,7 +1477,7 @@ msgstr "Luxemburg on horse"
 
 #: lu_int_wms.367
 msgid "ac_preizerdaul_ortho"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: l_wmts.368
 msgid "emwelt_biotop_kadaster_f"
@@ -1471,7 +1497,7 @@ msgstr "Habitats Natura 2000"
 
 #: lu_int_wms.372
 msgid "natur_an_emwelt_terrains"
-msgstr ""
+msgstr "Natur & Ëmwelt"
 
 #: lu_int_wms.373
 msgid "mobiliteit_bikeshare"
@@ -1531,11 +1557,11 @@ msgstr "Nature reserves (DIG)"
 
 #: lu_ext_wms.387
 msgid "Merovingien"
-msgstr ""
+msgstr "Merovingien"
 
 #: group.388
 msgid "Archeo"
-msgstr ""
+msgstr "Archéologie"
 
 #: lu_int_wms.389
 msgid "anf_peuplements_semenciers"
@@ -1555,7 +1581,7 @@ msgstr "Forest reserves"
 
 #: lu_ext_wms.393
 msgid "Prehistoire"
-msgstr ""
+msgstr "Préhistoire"
 
 #: lu_ext_wms.394
 msgid "Moyen Age"
@@ -1563,19 +1589,19 @@ msgstr ""
 
 #: lu_ext_wms.395
 msgid "Temps modernes"
-msgstr ""
+msgstr "Temps modernes"
 
 #: lu_ext_wms.396
 msgid "Epoque indefinie"
-msgstr ""
+msgstr "Epoque indéfinie"
 
 #: lu_ext_wms.397
 msgid "Protohistoire"
-msgstr ""
+msgstr "Protohistoire"
 
 #: lu_ext_wms.398
 msgid "Gallo-Romain"
-msgstr ""
+msgstr "Gallo-Romain"
 
 #: lu_int_wms.399
 msgid "anf_arbres_remarquables"
@@ -1735,7 +1761,7 @@ msgstr "PRE"
 
 #: lu_int_wms.438
 msgid "pag_lintgen_layer"
-msgstr ""
+msgstr "Land use plan of the municipality of Lintgen"
 
 #: group.439
 msgid "eau_new_Projekt_TIMIS_(usage_interne)"
@@ -1743,7 +1769,7 @@ msgstr "TIMIS Project"
 
 #: group.440
 msgid "group_lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: lu_int_wms.441
 msgid "at_pst3"
@@ -1787,7 +1813,7 @@ msgstr "Chemical status of the WB 2009"
 
 #: lu_int_wms.451
 msgid "env_corridors"
-msgstr ""
+msgstr "Corridors"
 
 #: lu_int_wms.452
 msgid "env_iba"
@@ -1839,11 +1865,11 @@ msgstr "Cadastral parcels"
 
 #: group.464
 msgid "olos_group"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: lu_int_wms.466
 msgid "topo_decoupage_5000_ed2015"
-msgstr ""
+msgstr "Mapsheets topographic plan 1:5000 edition 2015"
 
 #: group.467
 msgid "eau_new_Risikobeurteilung_2021"
@@ -1999,11 +2025,11 @@ msgstr "Nature & excursions"
 
 #: lu_int_wms.505
 msgid "lenoz_lmg"
-msgstr ""
+msgstr "Groceries stores"
 
 #: lu_int_wms.506
 msgid "lenoz_ecoles_old"
-msgstr ""
+msgstr "Schools"
 
 #: lu_int_wms.507
 msgid "ont_poi_5"
@@ -2011,7 +2037,7 @@ msgstr "Sports & leisure"
 
 #: lu_int_wms.508
 msgid "lenoz_creches"
-msgstr ""
+msgstr "Nurseries"
 
 #: lu_int_wms.509
 msgid "ont_poi_7"
@@ -2043,15 +2069,15 @@ msgstr "«Pickup» stations"
 
 #: lu_int_wms.516
 msgid "asta_flik_parcels_2015_prof"
-msgstr ""
+msgstr "FLIK parcels by ASTA version 2015"
 
 #: lu_int_wms.517
 msgid "lenoz_Banken"
-msgstr ""
+msgstr "Banks"
 
 #: lu_int_wms.518
 msgid "lenoz_Tankstelle"
-msgstr ""
+msgstr "Gas stations"
 
 #: group.519
 msgid "wrrl_intern_hs"
@@ -2067,19 +2093,19 @@ msgstr "Ecological focus areas "
 
 #: lu_int_wms.522
 msgid "lenoz_Ärzte"
-msgstr ""
+msgstr "Doctors"
 
 #: lu_int_wms.523
 msgid "lenoz_Post"
-msgstr ""
+msgstr "Post offices"
 
 #: lu_int_wms.524
 msgid "lenoz_Lycees"
-msgstr ""
+msgstr "High schools"
 
 #: lu_int_wms.525
 msgid "lenoz_Restaurants"
-msgstr ""
+msgstr "Restaurants"
 
 #: lu_int_wms.526
 msgid "ont_poi"

--- a/geoportailv3/locale/en/LC_MESSAGES/geoportailv3-server.po
+++ b/geoportailv3/locale/en/LC_MESSAGES/geoportailv3-server.po
@@ -6,97 +6,96 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: portail\n"
-"PO-Revision-Date: 2015-04-02 08:40+0000\n"
-"Last-Translator: geoportal-jk <jaykayone@gmail.com>\n"
-"Language-Team: English (http://www.transifex.com/projects/p/geoportailv3-lu/"
-"language/en/)\n"
-"Language: en\n"
+"PO-Revision-Date: 2015-07-10 13:47+0000\n"
+"Last-Translator: patrick weber <pweber@spatialbit.com>\n"
+"Language-Team: English (http://www.transifex.com/p/geoportailv3-lu/language/en/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Lingua 3.8\n"
+"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: geoportailv3/models.py:21
+#: ./geoportailv3/models.py:21
 msgid "Internal WMS layer"
 msgstr "Internal WMS layer"
 
-#: geoportailv3/models.py:22
+#: ./geoportailv3/models.py:22
 msgid "Internal WMS layers"
 msgstr ""
 
-#: geoportailv3/models.py:43
+#: ./geoportailv3/models.py:43
 msgid "External WMS layer"
 msgstr "External WMS layer"
 
-#: geoportailv3/models.py:44
+#: ./geoportailv3/models.py:44
 msgid "External WMS layers"
 msgstr ""
 
-#: geoportailv3/models.py:35
+#: ./geoportailv3/models.py:35
 msgid "Url"
 msgstr ""
 
-#: geoportailv3/models.py:36
+#: ./geoportailv3/models.py:36
 msgid "Layers"
 msgstr ""
 
-#: geoportailv3/models.py:37
+#: ./geoportailv3/models.py:37
 msgid "Is a POI"
 msgstr ""
 
-#: geoportailv3/models.py:38
+#: ./geoportailv3/models.py:38
 msgid "Collection ID"
 msgstr ""
 
-#: geoportailv3/models.py:39
+#: ./geoportailv3/models.py:39
 msgid "REST url"
 msgstr ""
 
-#: geoportailv3/models.py:57
+#: ./geoportailv3/models.py:57
 msgid "Category ID"
 msgstr ""
 
-#: geoportailv3/models.py:68
+#: ./geoportailv3/models.py:68
 msgid "Table name"
 msgstr ""
 
-#: geoportailv3/models.py:69
+#: ./geoportailv3/models.py:69
 msgid "URL Rest"
 msgstr ""
 
-#: geoportailv3/models.py:70
+#: ./geoportailv3/models.py:70
 msgid "Engine"
 msgstr ""
 
-#: geoportailv3/models.py:71
+#: ./geoportailv3/models.py:71
 msgid "Layer"
 msgstr ""
 
-#: geoportailv3/models.py:72
+#: ./geoportailv3/models.py:72
 msgid "Template file name"
 msgstr ""
 
-#: geoportailv3/models.py:74
+#: ./geoportailv3/models.py:74
 msgid "Is the template local or remote"
 msgstr ""
 
-#: geoportailv3/models.py:75
+#: ./geoportailv3/models.py:75
 msgid "Python function"
 msgstr ""
 
-#: geoportailv3/models.py:76
+#: ./geoportailv3/models.py:76
 msgid "Role"
 msgstr ""
 
-#: geoportailv3/models.py:77
+#: ./geoportailv3/models.py:77
 msgid "Attributes to keep"
 msgstr ""
 
-#: geoportailv3/models.py:78
+#: ./geoportailv3/models.py:78
 msgid "Id of the poi collection"
 msgstr ""
 
-#: geoportailv3/models.py:79
+#: ./geoportailv3/models.py:79
 msgid "Geometry column name"
 msgstr ""

--- a/geoportailv3/locale/fr/LC_MESSAGES/geoportailv3-client.po
+++ b/geoportailv3/locale/fr/LC_MESSAGES/geoportailv3-client.po
@@ -1,12 +1,13 @@
 # 
 # Translators:
 # Andre aDonno <andrea.donno@me.com>, 2015
+# Francis Kaell <francis.kaell@act.etat.lu>, 2015
 # Jeff Konnen <jeff.konnen@act.etat.lu>, 2015
 # patrick weber <pweber@spatialbit.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: portail\n"
-"PO-Revision-Date: 2015-07-08 14:18+0000\n"
+"PO-Revision-Date: 2015-07-13 06:43+0000\n"
 "Last-Translator: patrick weber <pweber@spatialbit.com>\n"
 "Language-Team: French (http://www.transifex.com/p/geoportailv3-lu/language/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -15,381 +16,406 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:91
 msgid "+ Add layers"
 msgstr "+ Ajouter une couche"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/static/js/share/sharedirective.js:110
+msgid "- link from geoportail.lu"
+msgstr "Carte du geoportail.lu"
+
+#: geoportailv3/templates/index.html:124
 msgid ""
 "A <em>right click</em> (tap and hold on mobile) will display information "
 "about the current location."
-msgstr ""
+msgstr "Un <em> clic droit </ em> (appuyez et maintenez sur mobile) affiche des informations sur l'emplacement actuel."
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:127
 msgid ""
 "A <em>short click</em> (tap on mobile) on a map feature will select the "
 "feature and show more information."
-msgstr ""
+msgstr "Un <em> clic court </ em> (tap sur mobile) sur une caractéristique de la carte permet de sélectionner la caractéristique et de montrer plus d'informations"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:165
 msgid "A0 landscape"
 msgstr "A0 paysage"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:164
 msgid "A0 portrait"
 msgstr "A0 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:163
 msgid "A1 landscape"
 msgstr "A1 paysage"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:162
 msgid "A1 portrait"
 msgstr "A1 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:161
 msgid "A2 landscape"
 msgstr "A2 paysage"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:160
 msgid "A2 portrait"
 msgstr "A2 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:159
 msgid "A3 landscape"
 msgstr "A3 paysage"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:158
 msgid "A3 portrait"
 msgstr "A3 portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:157
 msgid "A4 landscape"
 msgstr "A4 paysage"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:156
 msgid "A4 portrait"
 msgstr "A4 portrait"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:45
 msgid "Abort"
 msgstr "Abandonner"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:359
 msgid "Addresses"
 msgstr "Adresses"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:11
 msgid "Azimut"
 msgstr "Azimut"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:344
 msgid "Background"
 msgstr "Fond"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:333
 msgid "Background Layers"
 msgstr "Couche de Fond"
 
-#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html
+#: geoportailv3/static/js/exclusionmanagerservice.js:126
+msgid ""
+"Background has been deactivated because the layer {{layer}} cannot be "
+"displayed on top of it."
+msgstr "La carte d'arrière-fond a été désactivée car elle ne peut pas être affichée ensemble avec la couche {{layer}}"
+
+#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html:2
 msgid "Background layer:"
 msgstr "Couche de fond:"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:82
 msgid "Catalog"
 msgstr "Catalogue"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:4
 msgid "Changer"
 msgstr "Changer"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:136
 msgid ""
 "Click to continue drawing the line<br>Double-click or click last point to "
 "finish"
 msgstr "Cliquez pour continuer à tracer la ligne<br>Double cliquez pour finaliser"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:174
 msgid ""
 "Click to continue drawing the polygon<br>Double-click or click last point to"
 " finish"
 msgstr "Cliquez pour continuer à tracer le polygone<br>Double cliquez pour finaliser"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:193
 msgid "Click to finish"
 msgstr "Cliquez pour finir"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:173
 msgid "Click to start drawing area"
-msgstr "Cliquez pour commencer à tracer une aire"
+msgstr "Cliquez pour commencer à mesurer une aire"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:192
 msgid "Click to start drawing azimut"
-msgstr "Cliquez pour commencer à tracer un azimut"
+msgstr "Cliquez pour commencer à mesurer un azimut"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:152
 msgid "Click to start drawing length"
-msgstr "Cliquez pour commencer à tracer une longeur"
+msgstr "Cliquez pour commencer à mesurer une distance"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:135
 msgid "Click to start drawing profile"
-msgstr "Cliquez pour commencer à tracer un profil"
+msgstr "Cliquez pour commencer à mesurer un profil"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/urplang.html:7
+msgid "Cliquez dans l'image pour agrandir"
+msgstr ""
+
+#: geoportailv3/static/js/query/parcels.html:10
 msgid "Commander un extrait"
 msgstr "Commander un extrait"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:4
 msgid "Commune"
 msgstr "Commune"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:18
 msgid "Contact"
 msgstr "Contact"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:7
 msgid "Contenance"
 msgstr "Contenance"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:143
 msgid "Couches"
 msgstr "Couches"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:13
 msgid "Create a new user account"
 msgstr "Créer un nouvel utilisateur "
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:9
 msgid "Dernier mesurage"
 msgstr "Dernier mesurage"
 
-#: geoportailv3/static/js/layerinfo/popup.html
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/layerinfo/popup.html:9
+#: geoportailv3/static/js/query/mymaps.html:6
 msgid "Description"
 msgstr "Description"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:159
 msgid "Dessin"
 msgstr "Dessin"
 
-#: geoportailv3/static/js/profile/profile.html
+#: geoportailv3/static/js/profile/profile.html:5
 msgid "Draw a line on the map to display an elevation profile."
 msgstr "Tracez une ligne sur la carte pour afficher le profil d'élévation"
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:19
 msgid "Elevation"
 msgstr "Élévation"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:13
 msgid "Email"
 msgstr "Email"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:4
 msgid "Facebook"
 msgstr "Facebook"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:10
 msgid "Google Plus"
 msgstr "Google Plus"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:12
 msgid "I lost my password"
 msgstr "J'ai perdu mon mot de passe"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:171
 msgid "Imprimer"
 msgstr "Imprimer"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:149
 msgid "Infos"
 msgstr "Infos"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:11
 msgid "Invalid username or password"
 msgstr "Nom d'utilisateur ou mot de passe invalide"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:17
 msgid "Keywords"
 msgstr "Mots clés"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:304
 msgid "Layers"
 msgstr "Couches"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:35
 msgid "Legend"
 msgstr "Légende"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:3
 msgid "Length"
 msgstr "Longeur"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:153
 msgid "Lien 1"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:154
 msgid "Lien 2"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:155
 msgid "Lien 3"
 msgstr ""
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:27
 msgid "Link to the metadata"
 msgstr "Lien vers les metadonnées"
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:13
 msgid "Location Coordinates"
-msgstr ""
+msgstr "Coordonnées de position"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:4
 msgid "Login"
 msgstr "Se Connecter"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:23
 msgid "Logout"
 msgstr "Déconnecter"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:7
 msgid "Longeueur"
 msgstr "Longeur"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:146
 msgid "Mes Cartes"
 msgstr "My Maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:163
 msgid "Mesurer"
 msgstr "Mesurer"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:2
+#: geoportailv3/static/js/authentication/authentication.html:22
 msgid "My account"
 msgstr "Mon compte"
 
-#: geoportailv3/static/js/elevationservice.js
+#: geoportailv3/static/js/elevationservice.js:50
 msgid "N/A"
 msgstr "Pas accessible"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:8
 msgid "Name"
 msgstr "Nom"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:8
 msgid "Nature"
 msgstr "Nature"
 
-#: geoportailv3/static/js/layermanager/layermanager.html
+#: geoportailv3/static/js/layermanager/layermanager.html:1
 msgid "No layer selected"
 msgstr "Pas de couche sélectionnée"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:5
 msgid "Nom"
 msgstr "Nom"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:6
 msgid "Numero cadastral"
 msgstr "Numéro cadastral"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:176
 msgid "Partager"
 msgstr "Partager"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:8
 msgid "Password"
 msgstr "Mot de passe"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:15
 msgid "Profile"
 msgstr "Profil"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:8
 msgid "Rating"
 msgstr "Evaluation"
 
-#: geoportailv3/static/js/search/search.html
+#: geoportailv3/static/js/search/search.html:6
 msgid "Recherche adresse, parcelles, couches ..."
 msgstr "Recherche adresse, parcelles, couches"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:16
 msgid "Revision date"
 msgstr "Date de révision"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:5
 msgid "Section"
 msgstr "Section"
 
-#: geoportailv3/static/js/share/shorturl.html
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:4
+#: geoportailv3/static/js/share/shorturl.html:4
 msgid "Short Url"
-msgstr "Url courte"
+msgstr "Url"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:9
 msgid "Submit"
 msgstr "Soumettre"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:7
 msgid "Surface"
 msgstr "Surface"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/exclusionmanagerservice.js:139
+msgid ""
+"The layer <b>{{layersToRemove}}</b> has been removed because it cannot be "
+"displayed while the layer <b>{{layer}}</b> is displayed"
+msgid_plural ""
+"The layers <b>{{layersToRemove}}</b> have been removed because they cannot "
+"be displayed while the layer <b>{{layer}}</b> is displayed"
+msgstr[0] "La couche <b>{{layersToRemove}}</b> a été retirée parce-que elle ne peut pas être affichée avec la couche <b>{{layer}}</b> "
+msgstr[1] "Les couches <b>{{layersToRemove}}</b> ont été retirées parce-que elle ne peuvent pas être affichées avec la couche <b>{{layer}}</b> "
+
+#: geoportailv3/static/js/layerinfo/popup.html:38
 msgid "The legend is not available for this layer"
 msgstr "Pas de légende disponible pour cette couche"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:34
 msgid "The metadata is right now not available"
 msgstr "Les métadonnées ne sont pas accessibles pour le moment"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:2
 msgid "Theme"
 msgstr "Thème"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:6
 msgid "Title"
 msgstr "Titre"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:7
 msgid "Twitter"
 msgstr "Twitter"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:7
 msgid "Username"
 msgstr "Nom d'utilisatuer"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:13
 msgid "With legend"
 msgstr "Avec légende"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:108
 msgid "infos"
 msgstr "Infos"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:42
 msgid "lang"
 msgstr "Language"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:69
 msgid "layers"
 msgstr "Couches"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:11
 msgid "map_title"
 msgstr "Titre de Carte"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:77
 msgid "my_layers"
 msgstr "Mes couches"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:102
 msgid "my_maps"
 msgstr "My maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:34
 msgid "search"
 msgstr "Recherche"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:36
 msgid "user"
 msgstr "Utilisateur"
 
@@ -419,7 +445,7 @@ msgstr "Aménagement"
 
 #: theme.107 lu_ext_wms.292
 msgid "nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: theme.108
 msgid "go"
@@ -475,7 +501,7 @@ msgstr "Eau"
 
 #: theme.121
 msgid "remich"
-msgstr "PAG Remich"
+msgstr "Remich"
 
 #: theme.122
 msgid "test"
@@ -491,11 +517,11 @@ msgstr "Agriculture"
 
 #: theme.125
 msgid "preizerdaul"
-msgstr ""
+msgstr "Preizerdaul"
 
 #: theme.126
 msgid "wellenstein"
-msgstr "wellenstein_link_title"
+msgstr "Wellenstein"
 
 #: theme.127
 msgid "at_mobile"
@@ -507,11 +533,11 @@ msgstr "Eau"
 
 #: theme.129
 msgid "lintgen"
-msgstr ""
+msgstr "Lintgen"
 
 #: theme.130
 msgid "lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: theme.131
 msgid "municipalities"
@@ -523,7 +549,7 @@ msgstr ""
 
 #: theme.133 lu_int_wms.465
 msgid "olos"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: group.134
 msgid "emwelt_biotop_kadaster_mobile"
@@ -531,7 +557,7 @@ msgstr "Cadastre des biotopes des milieux ouverts"
 
 #: lu_int_wms.135
 msgid "ac_preizerdaul_ortho_2009"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: lu_int_wms.136
 msgid "asta_esp_lisiere"
@@ -563,7 +589,7 @@ msgstr "Cadastre des biotopes des milieux ouverts: Vergers"
 
 #: group.143
 msgid "group_nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: group.144
 msgid "env_natura2000"
@@ -671,7 +697,7 @@ msgstr "Zones protégées"
 
 #: group.170
 msgid "mittal_group"
-msgstr "Aménagement du territoire"
+msgstr "Parcelles du groupe Mittal"
 
 #: group.171
 msgid "presidence_restos"
@@ -927,7 +953,7 @@ msgstr "Images aériennes de 1951 (1:25k)"
 
 #: lu_int_wms.234
 msgid "mittal"
-msgstr ""
+msgstr "Parcelles du groupe Mittal"
 
 #: l_wmts.235
 msgid "ortho_2007"
@@ -1147,7 +1173,7 @@ msgstr "Courbes de niveau 10m"
 
 #: group.290
 msgid "group_ac_preizerdaul_pag"
-msgstr ""
+msgstr "PAG Preizerdaul"
 
 #: l_wmts.291
 msgid "wg_hangneigung_"
@@ -1451,7 +1477,7 @@ msgstr "Luxembourg à cheval"
 
 #: lu_int_wms.367
 msgid "ac_preizerdaul_ortho"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: l_wmts.368
 msgid "emwelt_biotop_kadaster_f"
@@ -1471,7 +1497,7 @@ msgstr "Habitats Natura 2000"
 
 #: lu_int_wms.372
 msgid "natur_an_emwelt_terrains"
-msgstr ""
+msgstr "Natur & Ëmwelt"
 
 #: lu_int_wms.373
 msgid "mobiliteit_bikeshare"
@@ -1531,11 +1557,11 @@ msgstr "Réserves naturelles (DIG)"
 
 #: lu_ext_wms.387
 msgid "Merovingien"
-msgstr ""
+msgstr "Merovingien"
 
 #: group.388
 msgid "Archeo"
-msgstr ""
+msgstr "Archéologie"
 
 #: lu_int_wms.389
 msgid "anf_peuplements_semenciers"
@@ -1563,19 +1589,19 @@ msgstr ""
 
 #: lu_ext_wms.395
 msgid "Temps modernes"
-msgstr ""
+msgstr "Temps modernes"
 
 #: lu_ext_wms.396
 msgid "Epoque indefinie"
-msgstr ""
+msgstr "Epoque indéfinie"
 
 #: lu_ext_wms.397
 msgid "Protohistoire"
-msgstr ""
+msgstr "Protohistoire"
 
 #: lu_ext_wms.398
 msgid "Gallo-Romain"
-msgstr ""
+msgstr "Gallo-Romain"
 
 #: lu_int_wms.399
 msgid "anf_arbres_remarquables"
@@ -1735,7 +1761,7 @@ msgstr "pre en fr"
 
 #: lu_int_wms.438
 msgid "pag_lintgen_layer"
-msgstr ""
+msgstr "Plan d'aménagement de la commune de Lintgen"
 
 #: group.439
 msgid "eau_new_Projekt_TIMIS_(usage_interne)"
@@ -1743,7 +1769,7 @@ msgstr "Projet TIMIS"
 
 #: group.440
 msgid "group_lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: lu_int_wms.441
 msgid "at_pst3"
@@ -1787,7 +1813,7 @@ msgstr "Etat chimique des ME souterraine 2009"
 
 #: lu_int_wms.451
 msgid "env_corridors"
-msgstr ""
+msgstr "Corridors"
 
 #: lu_int_wms.452
 msgid "env_iba"
@@ -1839,11 +1865,11 @@ msgstr "Parcelles cadastrales"
 
 #: group.464
 msgid "olos_group"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: lu_int_wms.466
 msgid "topo_decoupage_5000_ed2015"
-msgstr ""
+msgstr "Découpage plan topographique 1:5000 édition 2015"
 
 #: group.467
 msgid "eau_new_Risikobeurteilung_2021"
@@ -1999,11 +2025,11 @@ msgstr "Nature & excursions"
 
 #: lu_int_wms.505
 msgid "lenoz_lmg"
-msgstr ""
+msgstr "Épiceries"
 
 #: lu_int_wms.506
 msgid "lenoz_ecoles_old"
-msgstr ""
+msgstr "Écoles"
 
 #: lu_int_wms.507
 msgid "ont_poi_5"
@@ -2011,7 +2037,7 @@ msgstr "Sport & Loisir"
 
 #: lu_int_wms.508
 msgid "lenoz_creches"
-msgstr ""
+msgstr "Crèches"
 
 #: lu_int_wms.509
 msgid "ont_poi_7"
@@ -2043,15 +2069,15 @@ msgstr "Stations «Pickup»"
 
 #: lu_int_wms.516
 msgid "asta_flik_parcels_2015_prof"
-msgstr ""
+msgstr "Parcelles FLIK de l'ASTA version 2015"
 
 #: lu_int_wms.517
 msgid "lenoz_Banken"
-msgstr ""
+msgstr "Banques"
 
 #: lu_int_wms.518
 msgid "lenoz_Tankstelle"
-msgstr ""
+msgstr "Stations service"
 
 #: group.519
 msgid "wrrl_intern_hs"
@@ -2067,19 +2093,19 @@ msgstr "Surfaces d’intérêt écologique"
 
 #: lu_int_wms.522
 msgid "lenoz_Ärzte"
-msgstr ""
+msgstr "Docteurs"
 
 #: lu_int_wms.523
 msgid "lenoz_Post"
-msgstr ""
+msgstr "Postes"
 
 #: lu_int_wms.524
 msgid "lenoz_Lycees"
-msgstr ""
+msgstr "Lycées"
 
 #: lu_int_wms.525
 msgid "lenoz_Restaurants"
-msgstr ""
+msgstr "Restaurants"
 
 #: lu_int_wms.526
 msgid "ont_poi"

--- a/geoportailv3/locale/fr/LC_MESSAGES/geoportailv3-server.po
+++ b/geoportailv3/locale/fr/LC_MESSAGES/geoportailv3-server.po
@@ -4,97 +4,96 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: portail\n"
-"POT-Creation-Date: 2015-01-16 16:16+0100\n"
-"PO-Revision-Date: 2015-01-21 08:17+0000\n"
+"PO-Revision-Date: 2015-06-16 09:34+0000\n"
 "Last-Translator: Stéphane Brunner <stephane.brunner@camptocamp.com>\n"
-"Language-Team: French (http://www.transifex.com/projects/p/geoportailv3-lu/"
-"language/fr/)\n"
-"Language: fr\n"
+"Language-Team: French (http://www.transifex.com/p/geoportailv3-lu/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingua 3.8\n"
+"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: geoportailv3/models.py:21
+#: ./geoportailv3/models.py:21
 msgid "Internal WMS layer"
 msgstr ""
 
-#: geoportailv3/models.py:22
+#: ./geoportailv3/models.py:22
 msgid "Internal WMS layers"
 msgstr ""
 
-#: geoportailv3/models.py:43
+#: ./geoportailv3/models.py:43
 msgid "External WMS layer"
 msgstr ""
 
-#: geoportailv3/models.py:44
+#: ./geoportailv3/models.py:44
 msgid "External WMS layers"
 msgstr ""
 
-#: geoportailv3/models.py:35
+#: ./geoportailv3/models.py:35
 msgid "Url"
 msgstr ""
 
-#: geoportailv3/models.py:36
+#: ./geoportailv3/models.py:36
 msgid "Layers"
 msgstr ""
 
-#: geoportailv3/models.py:37
+#: ./geoportailv3/models.py:37
 msgid "Is a POI"
 msgstr ""
 
-#: geoportailv3/models.py:38
+#: ./geoportailv3/models.py:38
 msgid "Collection ID"
 msgstr ""
 
-#: geoportailv3/models.py:39
+#: ./geoportailv3/models.py:39
 msgid "REST url"
 msgstr ""
 
-#: geoportailv3/models.py:57
+#: ./geoportailv3/models.py:57
 msgid "Category ID"
 msgstr ""
 
-#: geoportailv3/models.py:68
+#: ./geoportailv3/models.py:68
 msgid "Table name"
 msgstr ""
 
-#: geoportailv3/models.py:69
+#: ./geoportailv3/models.py:69
 msgid "URL Rest"
 msgstr ""
 
-#: geoportailv3/models.py:70
+#: ./geoportailv3/models.py:70
 msgid "Engine"
 msgstr ""
 
-#: geoportailv3/models.py:71
+#: ./geoportailv3/models.py:71
 msgid "Layer"
 msgstr ""
 
-#: geoportailv3/models.py:72
+#: ./geoportailv3/models.py:72
 msgid "Template file name"
 msgstr ""
 
-#: geoportailv3/models.py:74
+#: ./geoportailv3/models.py:74
 msgid "Is the template local or remote"
 msgstr ""
 
-#: geoportailv3/models.py:75
+#: ./geoportailv3/models.py:75
 msgid "Python function"
 msgstr ""
 
-#: geoportailv3/models.py:76
+#: ./geoportailv3/models.py:76
 msgid "Role"
 msgstr ""
 
-#: geoportailv3/models.py:77
+#: ./geoportailv3/models.py:77
 msgid "Attributes to keep"
 msgstr ""
 
-#: geoportailv3/models.py:78
+#: ./geoportailv3/models.py:78
 msgid "Id of the poi collection"
 msgstr ""
 
-#: geoportailv3/models.py:79
+#: ./geoportailv3/models.py:79
 msgid "Geometry column name"
 msgstr ""

--- a/geoportailv3/locale/lb/LC_MESSAGES/geoportailv3-client.po
+++ b/geoportailv3/locale/lb/LC_MESSAGES/geoportailv3-client.po
@@ -1,11 +1,12 @@
 # 
 # Translators:
 # Andre aDonno <andrea.donno@me.com>, 2015
+# Francis Kaell <francis.kaell@act.etat.lu>, 2015
 # patrick weber <pweber@spatialbit.com>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: portail\n"
-"PO-Revision-Date: 2015-07-08 14:48+0000\n"
+"PO-Revision-Date: 2015-07-10 14:04+0000\n"
 "Last-Translator: patrick weber <pweber@spatialbit.com>\n"
 "Language-Team: Luxembourgish (http://www.transifex.com/p/geoportailv3-lu/language/lb/)\n"
 "MIME-Version: 1.0\n"
@@ -14,383 +15,408 @@ msgstr ""
 "Language: lb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:91
 msgid "+ Add layers"
 msgstr "+ Layeren beisetzen"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/static/js/share/sharedirective.js:110
+msgid "- link from geoportail.lu"
+msgstr "Kaart aus geoportail.lu"
+
+#: geoportailv3/templates/index.html:124
 msgid ""
 "A <em>right click</em> (tap and hold on mobile) will display information "
 "about the current location."
-msgstr ""
+msgstr "Duerch <em>Rietsklick</em> (tippen an gedréckt haalen op mobil) ginn d'Informatiounen iwwert déi aktuell Positioun ugewisen"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:127
 msgid ""
 "A <em>short click</em> (tap on mobile) on a map feature will select the "
 "feature and show more information."
-msgstr ""
+msgstr "Duerch <em>Klick</em> (tippen op mobil) op eng Funktioun gëtt dës ausgewielt an méi Informatiounen ugewisen"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:165
 msgid "A0 landscape"
-msgstr "A0 Landscape"
+msgstr "A0 Landschaft"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:164
 msgid "A0 portrait"
 msgstr "A0 Portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:163
 msgid "A1 landscape"
-msgstr "A1 Landscape"
+msgstr "A1 Landschaft"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:162
 msgid "A1 portrait"
 msgstr "A1 Portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:161
 msgid "A2 landscape"
-msgstr "A2 Landscape"
+msgstr "A2 Landschaft"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:160
 msgid "A2 portrait"
 msgstr "A2 Portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:159
 msgid "A3 landscape"
-msgstr "A3 Landscape"
+msgstr "A3 Landschaft"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:158
 msgid "A3 portrait"
 msgstr "A3 Portrait"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:157
 msgid "A4 landscape"
-msgstr "A4 Landscape"
+msgstr "A4 Landschaft"
 
-#: geoportailv3/static/js/print/printdirective.js
+#: geoportailv3/static/js/print/printdirective.js:156
 msgid "A4 portrait"
 msgstr "A4 Portrait"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:45
 msgid "Abort"
-msgstr "Ophaalen"
+msgstr "Ënnerbriechen"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:359
 msgid "Addresses"
 msgstr "Adressen"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:11
 msgid "Azimut"
 msgstr "Azimut"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:344
 msgid "Background"
 msgstr "Hannergrond"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:333
 msgid "Background Layers"
 msgstr "Hannergrondlayeren"
 
-#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html
+#: geoportailv3/static/js/exclusionmanagerservice.js:126
+msgid ""
+"Background has been deactivated because the layer {{layer}} cannot be "
+"displayed on top of it."
+msgstr "D' Hannergrondkaart gouf ausgeschalt well se net mam Layer {{layer}} kann ugewise ginn"
+
+#: geoportailv3/static/js/backgroundlayer/backgroundlayer.html:2
 msgid "Background layer:"
 msgstr "Hannergrondlayer:"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:82
 msgid "Catalog"
 msgstr "Katalog"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:4
 msgid "Changer"
 msgstr "Wiesselen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:136
 msgid ""
 "Click to continue drawing the line<br>Double-click or click last point to "
 "finish"
-msgstr "Klickt fir mam zeechnen vun der Linn weiderzefueren <br> Duebelklick fir ofzeschléissen"
+msgstr "Klickt fir mam Zeechnen vun der Linn weiderzefueren <br> Duebelklick fir ofzeschléissen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:174
 msgid ""
 "Click to continue drawing the polygon<br>Double-click or click last point to"
 " finish"
-msgstr "Klickt fir mam zeechnen vum Polygon weiderzefueren <br> Duebelklick fir ofzeschléissen"
+msgstr "Klickt fir mam Zeechnen vum Polygon weiderzefueren <br> Duebelklick fir ofzeschléissen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:193
 msgid "Click to finish"
 msgstr "Klickt fir ofzeschléissen"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:173
 msgid "Click to start drawing area"
-msgstr "Klickt fir mam zeechnen vun enger Fläch unzefänken"
+msgstr "Klickt fir mam Moossen vun enger Fläch unzefänken"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:192
 msgid "Click to start drawing azimut"
-msgstr "Klickt fir mam zeechnen vun engem Azimut unzefänken"
+msgstr "Klickt fir mam Moossen vun engem Azimut unzefänken"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:152
 msgid "Click to start drawing length"
-msgstr "Klickt fir mam zeechnen vun enger Längt unzefänken"
+msgstr "Klickt fir mam Moossen vun enger Längt unzefänken"
 
-#: geoportailv3/static/js/measure/measuredirective.js
+#: geoportailv3/static/js/measure/measuredirective.js:135
 msgid "Click to start drawing profile"
-msgstr "Klickt fir mam zeechnen vun engem Profil unzefänken"
+msgstr "Klickt fir mam Moossen vun engem Profil unzefänken"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/urplang.html:7
+msgid "Cliquez dans l'image pour agrandir"
+msgstr ""
+
+#: geoportailv3/static/js/query/parcels.html:10
 msgid "Commander un extrait"
 msgstr "Extrait bestellen"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:4
 msgid "Commune"
 msgstr "Gemeng"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:18
 msgid "Contact"
 msgstr "Kontakt"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:7
 msgid "Contenance"
 msgstr "Flächeninhalt"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:143
 msgid "Couches"
 msgstr "Layeren"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:13
 msgid "Create a new user account"
-msgstr "E neien Benotzerkont Erstellen"
+msgstr "E neien Benotzerkont opmaachen"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:9
 msgid "Dernier mesurage"
 msgstr "Leschten Mesurage"
 
-#: geoportailv3/static/js/layerinfo/popup.html
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/layerinfo/popup.html:9
+#: geoportailv3/static/js/query/mymaps.html:6
 msgid "Description"
 msgstr "Beschreiwung"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:159
 msgid "Dessin"
 msgstr "Zeechnen"
 
-#: geoportailv3/static/js/profile/profile.html
+#: geoportailv3/static/js/profile/profile.html:5
 msgid "Draw a line on the map to display an elevation profile."
-msgstr "Zeechent eng Linn ob der Kaart fir den Héichtenprofil unzeweisen"
+msgstr "Zeechent eng Linn op der Kaart fir den Héichtenprofil unzeweisen"
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:19
 msgid "Elevation"
-msgstr "Héichten"
+msgstr "Héicht"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:13
 msgid "Email"
 msgstr "Email"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:4
 msgid "Facebook"
 msgstr "Facebook"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:10
 msgid "Google Plus"
 msgstr "Google Plus"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:12
 msgid "I lost my password"
-msgstr "Ech hu mäin Passwuert verluer"
+msgstr "Ech hu mäi Passwuert verluer"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:171
 msgid "Imprimer"
 msgstr "Drécken"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:149
 msgid "Infos"
 msgstr "Infos"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:11
 msgid "Invalid username or password"
 msgstr "Ongültegen Benotzernumm oder Passwuert"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:17
 msgid "Keywords"
 msgstr "Wichteg Wierder"
 
-#: geoportailv3/static/js/search/searchdirective.js
+#: geoportailv3/static/js/search/searchdirective.js:304
 msgid "Layers"
 msgstr "Layeren"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:35
 msgid "Legend"
-msgstr "Legende"
+msgstr "Legend"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:3
 msgid "Length"
 msgstr "Längt"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:153
 msgid "Lien 1"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:154
 msgid "Lien 2"
 msgstr ""
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:155
 msgid "Lien 3"
 msgstr ""
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:27
 msgid "Link to the metadata"
 msgstr "Link op d'Metadaten"
 
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:13
 msgid "Location Coordinates"
-msgstr ""
+msgstr "Positiounskoordinaten"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:4
 msgid "Login"
 msgstr "Aloggen"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:23
 msgid "Logout"
 msgstr "Ausloggen"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:7
 msgid "Longeueur"
 msgstr "Längt"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:146
 msgid "Mes Cartes"
 msgstr "My Maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:163
 msgid "Mesurer"
-msgstr "Moosen"
+msgstr "Moossen"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:2
+#: geoportailv3/static/js/authentication/authentication.html:22
 msgid "My account"
-msgstr "Mein Konto"
+msgstr "Mäi Konto"
 
-#: geoportailv3/static/js/elevationservice.js
+#: geoportailv3/static/js/elevationservice.js:50
 msgid "N/A"
 msgstr ""
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:8
 msgid "Name"
 msgstr "Numm"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:8
 msgid "Nature"
-msgstr ""
+msgstr "Notzung"
 
-#: geoportailv3/static/js/layermanager/layermanager.html
+#: geoportailv3/static/js/layermanager/layermanager.html:1
 msgid "No layer selected"
 msgstr "Keen Layer ausgewielt"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:5
 msgid "Nom"
 msgstr "Numm"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:6
 msgid "Numero cadastral"
 msgstr "Kadasternummer"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:176
 msgid "Partager"
 msgstr "Deelen"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:8
 msgid "Password"
 msgstr "Passwuert"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:15
 msgid "Profile"
 msgstr "Profil"
 
-#: geoportailv3/static/js/query/mymaps.html
+#: geoportailv3/static/js/query/mymaps.html:8
 msgid "Rating"
 msgstr "Bewäertung"
 
-#: geoportailv3/static/js/search/search.html
+#: geoportailv3/static/js/search/search.html:6
 msgid "Recherche adresse, parcelles, couches ..."
-msgstr "SIch Adressen, Parzellen, Layeren ... "
+msgstr "Sich Adressen, Parzellen, Layeren ... "
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:16
 msgid "Revision date"
-msgstr ""
+msgstr "Revisiounsdatum"
 
-#: geoportailv3/static/js/query/parcels.html
+#: geoportailv3/static/js/query/parcels.html:5
 msgid "Section"
-msgstr ""
+msgstr "Sectioun"
 
-#: geoportailv3/static/js/share/shorturl.html
-#: geoportailv3/static/js/locationinfo/locationinfo.html
+#: geoportailv3/static/js/locationinfo/locationinfo.html:4
+#: geoportailv3/static/js/share/shorturl.html:4
 msgid "Short Url"
-msgstr "Kuerz Adress"
+msgstr "Url"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:9
 msgid "Submit"
 msgstr "Aloggen"
 
-#: geoportailv3/static/js/measure/measure.html
+#: geoportailv3/static/js/measure/measure.html:7
 msgid "Surface"
 msgstr "Fläch"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/exclusionmanagerservice.js:139
+msgid ""
+"The layer <b>{{layersToRemove}}</b> has been removed because it cannot be "
+"displayed while the layer <b>{{layer}}</b> is displayed"
+msgid_plural ""
+"The layers <b>{{layersToRemove}}</b> have been removed because they cannot "
+"be displayed while the layer <b>{{layer}}</b> is displayed"
+msgstr[0] "De Layer <b>{{layersToRemove}}</b> gouf ewechgehol, well en net dierf mam Layer <b>{{layer}}</b> ugewisen gin"
+msgstr[1] "D'Layeren <b>{{layersToRemove}}</b> goufen ewechgeholl, well se net dierfen mam Layer <b>{{layer}}</b> ugewisen ginn"
+
+#: geoportailv3/static/js/layerinfo/popup.html:38
 msgid "The legend is not available for this layer"
-msgstr "Keng spezifësch Legend fier dese Layer"
+msgstr "Keng spezifesch Legend fir dëse Layer"
 
-#: geoportailv3/static/js/layerinfo/popup.html
+#: geoportailv3/static/js/layerinfo/popup.html:34
 msgid "The metadata is right now not available"
-msgstr "Et si keng Metadaten fir dëse Layer verfügbar"
+msgstr "Et gi keng Metadaten fir dëse Layer"
 
-#: geoportailv3/static/js/themeswitcher/themes.html
+#: geoportailv3/static/js/themeswitcher/themes.html:2
 msgid "Theme"
 msgstr "Thema"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:6
 msgid "Title"
 msgstr "Titel"
 
-#: geoportailv3/static/js/share/share.html
+#: geoportailv3/static/js/share/share.html:7
 msgid "Twitter"
 msgstr "Twitter"
 
-#: geoportailv3/static/js/authentication/authentication.html
+#: geoportailv3/static/js/authentication/authentication.html:7
 msgid "Username"
 msgstr "Benotzernumm"
 
-#: geoportailv3/static/js/print/print.html
+#: geoportailv3/static/js/print/print.html:13
 msgid "With legend"
-msgstr "Mat Legende"
+msgstr "Mat Legend"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:108
 msgid "infos"
-msgstr ""
+msgstr "Informatiounen"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:42
 msgid "lang"
-msgstr ""
+msgstr "Sprooch"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:69
 msgid "layers"
-msgstr ""
+msgstr "Layeren"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:11
 msgid "map_title"
-msgstr ""
+msgstr "Kaartennumm"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:77
 msgid "my_layers"
-msgstr "Meng Layeren"
+msgstr "Méng Layeren"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:102
 msgid "my_maps"
 msgstr "My maps"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:34
 msgid "search"
 msgstr "Sich"
 
-#: geoportailv3/templates/index.html
+#: geoportailv3/templates/index.html:36
 msgid "user"
-msgstr ""
+msgstr "Benotzer"
 
 #: theme.101
 msgid "preemption"
@@ -418,15 +444,15 @@ msgstr "Landesplanung"
 
 #: theme.107 lu_ext_wms.292
 msgid "nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: theme.108
 msgid "go"
-msgstr ""
+msgstr "Géomètres officiels"
 
 #: theme.109
 msgid "prof"
-msgstr ""
+msgstr "Professionell Notzer"
 
 #: theme.110
 msgid "main_mobile"
@@ -434,7 +460,7 @@ msgstr "Allgemeng"
 
 #: theme.111
 msgid "user_content_mobile"
-msgstr "Kaarten vun Benotzer"
+msgstr "Kaarten vu Benotzer"
 
 #: theme.112
 msgid "api"
@@ -442,11 +468,11 @@ msgstr "Camping"
 
 #: theme.113
 msgid "arbed"
-msgstr ""
+msgstr "ARBED"
 
 #: theme.114 group.257
 msgid "commande"
-msgstr "Municipality"
+msgstr "Bestellung"
 
 #: theme.115
 msgid "ortho_mobile"
@@ -458,7 +484,7 @@ msgstr "Tourismus"
 
 #: theme.117
 msgid "main"
-msgstr ""
+msgstr "Haaptthema"
 
 #: theme.118
 msgid "cadastre_mobile"
@@ -474,7 +500,7 @@ msgstr "Waasser"
 
 #: theme.121
 msgid "remich"
-msgstr "PAG Remich"
+msgstr "Remich"
 
 #: theme.122
 msgid "test"
@@ -490,11 +516,11 @@ msgstr "Landwirtschaft"
 
 #: theme.125
 msgid "preizerdaul"
-msgstr ""
+msgstr "Preizerdaul"
 
 #: theme.126
 msgid "wellenstein"
-msgstr "wellenstein_link_title"
+msgstr "Wellesteen"
 
 #: theme.127
 msgid "at_mobile"
@@ -502,19 +528,19 @@ msgstr "Raumplanung"
 
 #: theme.128
 msgid "eau"
-msgstr "Moossen"
+msgstr "Wasser"
 
 #: theme.129
 msgid "lintgen"
-msgstr ""
+msgstr "Lëntgen"
 
 #: theme.130
 msgid "lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: theme.131
 msgid "municipalities"
-msgstr ""
+msgstr "Gemengen"
 
 #: theme.132
 msgid "presidence2015"
@@ -522,7 +548,7 @@ msgstr ""
 
 #: theme.133 lu_int_wms.465
 msgid "olos"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: group.134
 msgid "emwelt_biotop_kadaster_mobile"
@@ -530,7 +556,7 @@ msgstr "Offeland-Biotopkadaster"
 
 #: lu_int_wms.135
 msgid "ac_preizerdaul_ortho_2009"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: lu_int_wms.136
 msgid "asta_esp_lisiere"
@@ -550,7 +576,7 @@ msgstr "Offeland-Biotopkadaster: Flächenelementer ouni Bongerten"
 
 #: l_wmts.140
 msgid "emwelt_biotop_kadaster_b_mobile"
-msgstr "Offeland-Biotopkadaster: Pufferzone"
+msgstr "Offeland-Biotopkadaster: Pufferzonen"
 
 #: l_wmts.141
 msgid "emwelt_biotop_kadaster_p_mobile"
@@ -562,7 +588,7 @@ msgstr "Offeland-Biotopkadaster: Bongerten"
 
 #: group.143
 msgid "group_nordstad"
-msgstr ""
+msgstr "Nordstad"
 
 #: group.144
 msgid "env_natura2000"
@@ -586,11 +612,11 @@ msgstr "Regional touristesch Kaart 1:20000 R"
 
 #: lu_ext_wms.149
 msgid "tour_nordic_walking"
-msgstr "Nordic Walking Parcs"
+msgstr "Nordic Walking"
 
 #: lu_int_wms.150
 msgid "parcelles_preemption"
-msgstr ""
+msgstr "Parzellen Virkafsrecht"
 
 #: l_wmts.151
 msgid "addresses"
@@ -622,11 +648,11 @@ msgstr "Fluchhafekaméidi 2011 (LDEN)"
 
 #: lu_ext_wms.158
 msgid "tour_cfl"
-msgstr "CFL: Bunn, Wanderen, Velo"
+msgstr "CFL: Bunn, Wanderen, Vëlo"
 
 #: lu_ext_wms.159
 msgid "tour_pistes_velo"
-msgstr "Velosweeër"
+msgstr "Vëlosweeër"
 
 #: group.160
 msgid "eau_luft_sat_bilder"
@@ -662,7 +688,7 @@ msgstr "Corine Landcover 2006"
 
 #: lu_ext_wms.168
 msgid "tour_quality_trails"
-msgstr "aner Qualitéitswéër"
+msgstr "Aner Qualitéitsweeër"
 
 #: group.169
 msgid "eau_zones_protegees"
@@ -670,7 +696,7 @@ msgstr "Schutzgebidder"
 
 #: group.170
 msgid "mittal_group"
-msgstr "Landesplanung"
+msgstr "Parzellen vum Grupp Mittal "
 
 #: group.171
 msgid "presidence_restos"
@@ -702,7 +728,7 @@ msgstr "Kadasterparzellen"
 
 #: l_wmts.178
 msgid "ivv_grosslagen"
-msgstr "Lagen am Weibau"
+msgstr "Lagen am Wäibau"
 
 #: lu_ext_wms.179
 msgid "tour_autopedestre"
@@ -714,11 +740,11 @@ msgstr "Gememgeweeër"
 
 #: group.181
 msgid "luft_und_satellitenbilder"
-msgstr "Loft a Satellitebilder"
+msgstr "Loft- a Satellitebiller"
 
 #: group.182
 msgid "tour_sentiers_locaux"
-msgstr "Lokal Wanderweeër (nët vun der DG Tourismus ënnerhalen)"
+msgstr "Lokal Wanderweeër (nët vun der DG Tourismus ënnerhal)"
 
 #: group.183
 msgid "anf_secteurs_ecologiques_group"
@@ -754,7 +780,7 @@ msgstr "Ëmwelt, Biologie a Geologie"
 
 #: l_wmts.191
 msgid "topo_decoupage_tc"
-msgstr "Blaatschnett Regional Kaart"
+msgstr "Blatschnëtt Regional Kaart"
 
 #: lu_ext_wms.192
 msgid "tour_mullerthal_trail"
@@ -774,7 +800,7 @@ msgstr "Héicht"
 
 #: l_wmts.196
 msgid "topo_decoupage_5000"
-msgstr "Blaatschnett Regional Kaart"
+msgstr "Blatschnëtt Regionalkaart"
 
 #: group.197
 msgid "infrastrucktur_une_kommunikation"
@@ -790,7 +816,7 @@ msgstr "Verkéiersnetzer"
 
 #: lu_ext_wms.200
 msgid "tour_sentiers_ajl"
-msgstr "Jugendherbergs Weeër"
+msgstr "Jugendherbergs-Weeër"
 
 #: lu_ext_wms.201
 msgid "tour_temp"
@@ -802,11 +828,11 @@ msgstr "Agrikulturdaten"
 
 #: l_wmts.203
 msgid "buildings"
-msgstr "Gebeier"
+msgstr "Gebaier"
 
 #: l_wmts.204
 msgid "topo_decoupage_100k"
-msgstr "Blaatschnett Regional Kaart"
+msgstr "Blatschnëtt Regional Kaart"
 
 #: l_wmts.205
 msgid "TOPO_CARTESHISTO_1964"
@@ -850,7 +876,7 @@ msgstr "Komplettiwersiicht"
 
 #: l_wmts.215
 msgid "decoupage_geo25_50k"
-msgstr ""
+msgstr "Blatschnëtt Geologesch Kaart"
 
 #: group.216
 msgid "verkehrsnetze_tourisme"
@@ -882,7 +908,7 @@ msgstr "Saint Jacques Wee"
 
 #: l_wmts.223
 msgid "topo_decoupage_50k"
-msgstr "Blaatschnett Regional Kaart"
+msgstr "Blatschnëtt Regionalkaart"
 
 #: l_wmts.224
 msgid "TOPO_CARTES_1944"
@@ -926,7 +952,7 @@ msgstr "Loftbiller vun 1951 (1:25k)"
 
 #: lu_int_wms.234
 msgid "mittal"
-msgstr ""
+msgstr "Parzellen vum Grupp Mittal "
 
 #: l_wmts.235
 msgid "ortho_2007"
@@ -966,7 +992,7 @@ msgstr "Vu Benotzer publizéierte Contenu"
 
 #: l_wmts.244
 msgid "ivv_kleinlagen"
-msgstr "Klenglagen am Weibau"
+msgstr "Klenglagen am Wäibau"
 
 #: group.245
 msgid "anf_forets"
@@ -1026,7 +1052,7 @@ msgstr "Kadaster Urpläng"
 
 #: l_wmts.260
 msgid "ac_wellenstein_pag_limites"
-msgstr "Limitem"
+msgstr "Limiten"
 
 #: l_wmts.261
 msgid "ac_wellenstein_pag_voies_acces"
@@ -1058,7 +1084,7 @@ msgstr "PAG"
 
 #: l_wmts.268
 msgid "topo_decoupage_r"
-msgstr "Blaatschnett Regional Kaart"
+msgstr "Blatschnëtt Regional Kaart"
 
 #: l_wmts.269
 msgid "sections_cadastrales_labels"
@@ -1082,7 +1108,7 @@ msgstr "Net kategoriséiert"
 
 #: lu_ext_wms.274
 msgid "user_content_poi"
-msgstr "Points of interest"
+msgstr "Interessant Punkten"
 
 #: l_wmts.275
 msgid "pedologie_100k"
@@ -1122,7 +1148,7 @@ msgstr "Verwaltungseenheeten vun der Naturverwaltung"
 
 #: group.284
 msgid "tour_velo_v2"
-msgstr "Velos- & Mountainbike Weeër"
+msgstr "Vëlos- & Mountainbike Weeër"
 
 #: l_wmts.285
 msgid "ac_wellenstein_pag_alignements_a_preserver"
@@ -1134,7 +1160,7 @@ msgstr "Wiederstatiounen"
 
 #: group.287
 msgid "gebaude_prof"
-msgstr "Gebeier"
+msgstr "Gebaier"
 
 #: l_wmts.288
 msgid "TOPO_CARTESHISTO_1989"
@@ -1146,7 +1172,7 @@ msgstr "Héichtelinnen 10m"
 
 #: group.290
 msgid "group_ac_preizerdaul_pag"
-msgstr ""
+msgstr "PAG Preizerdaul"
 
 #: l_wmts.291
 msgid "wg_hangneigung_"
@@ -1162,7 +1188,7 @@ msgstr "Topografesch Kaarten"
 
 #: l_wmts.295
 msgid "wg_ikonos_satellitendaten"
-msgstr "Satellitendonnée Ikonos"
+msgstr "Ikonos Satellitendaten "
 
 #: lu_ext_wms.296
 msgid "tour_pistes_vtt"
@@ -1182,7 +1208,7 @@ msgstr "FLIK Referenzparzellen Wéngerten 2014"
 
 #: lu_int_wms.300
 msgid "buildings_eau"
-msgstr "Gebeier"
+msgstr "Gebaier"
 
 #: lu_int_wms.301
 msgid "toponymes_go"
@@ -1218,7 +1244,7 @@ msgstr "Ze erhale Flächen"
 
 #: l_wmts.309
 msgid "decoupage_geo25k"
-msgstr "Blaatschnett Regional Kaart"
+msgstr "Blatschnëtt Regionalkaart"
 
 #: group.310
 msgid "asta"
@@ -1334,7 +1360,7 @@ msgstr "International Schutzgebidder"
 
 #: group.338
 msgid "weinbau"
-msgstr "Weibau"
+msgstr "Wäibau"
 
 #: group.339
 msgid "tour_auto_moto_v2"
@@ -1342,7 +1368,7 @@ msgstr "Oldtimer- & Moto Touren"
 
 #: group.340
 msgid "group_preemption"
-msgstr ""
+msgstr "Virkafsrecht"
 
 #: group.341
 msgid "lebensraume_une_biotope"
@@ -1350,7 +1376,7 @@ msgstr "Liewensraim a Biotoper"
 
 #: group.342
 msgid "gebaude"
-msgstr "Gebeier"
+msgstr "Gebaier"
 
 #: group.343
 msgid "asta_zones_prot"
@@ -1374,7 +1400,7 @@ msgstr "PAG Remich"
 
 #: l_wmts.348
 msgid "topo_decoupage_ortho"
-msgstr "Bladschnëtt Orthophotos"
+msgstr "Blatschnëtt Orthophotos"
 
 #: l_wmts.349
 msgid "cantons_labels"
@@ -1382,7 +1408,7 @@ msgstr "Kantoner (Nimm)"
 
 #: lu_int_wms.350
 msgid "all_maps_root_account"
-msgstr "All ëffentlech Kaarten vun mengem Haptkont"
+msgstr "All ëffentlech Kaarten vun méngem Haaptkont"
 
 #: lu_int_wms.351
 msgid "all_my_maps"
@@ -1442,7 +1468,7 @@ msgstr "Mehrfachnotzung"
 
 #: lu_int_wms.365
 msgid "affaires"
-msgstr ""
+msgstr "Affairen"
 
 #: lu_ext_wms.366
 msgid "luxembourg_on_horse"
@@ -1450,7 +1476,7 @@ msgstr "Lëtzebuerg zu Päerd"
 
 #: lu_int_wms.367
 msgid "ac_preizerdaul_ortho"
-msgstr "Orthophoto Remich"
+msgstr "Orthophoto Preizerdaul"
 
 #: l_wmts.368
 msgid "emwelt_biotop_kadaster_f"
@@ -1458,7 +1484,7 @@ msgstr "Flächenelementer ouni Bongerten"
 
 #: l_wmts.369
 msgid "emwelt_biotop_kadaster_b"
-msgstr "Pufferzone"
+msgstr "Pufferzonen"
 
 #: group.370
 msgid "emwelt_biotop_kadaster"
@@ -1470,7 +1496,7 @@ msgstr "Habitater Natura 2000"
 
 #: lu_int_wms.372
 msgid "natur_an_emwelt_terrains"
-msgstr ""
+msgstr "Natur & Ëmwelt"
 
 #: lu_int_wms.373
 msgid "mobiliteit_bikeshare"
@@ -1486,7 +1512,7 @@ msgstr "Bongerten"
 
 #: lu_ext_wms.376
 msgid "tour_pistes_velo_mymaps"
-msgstr "National Velosweeër"
+msgstr "National Vëlosweeër"
 
 #: group.377
 msgid "eau_new_Trinkwasser_Schutzzonen_(ZPS)"
@@ -1494,7 +1520,7 @@ msgstr "Drénkwaasserschutzgebidder [ZPS]"
 
 #: lu_int_wms.378
 msgid "topo_decoupage_ortho_2013"
-msgstr "Bladschnëtt Orthophotos"
+msgstr "Blatschnëtt Orthophotos"
 
 #: lu_int_wms.379
 msgid "prpl_luref"
@@ -1530,11 +1556,11 @@ msgstr "Naturschutzgebidder (DIG)"
 
 #: lu_ext_wms.387
 msgid "Merovingien"
-msgstr ""
+msgstr "Merovingien"
 
 #: group.388
 msgid "Archeo"
-msgstr ""
+msgstr "Archéologie"
 
 #: lu_int_wms.389
 msgid "anf_peuplements_semenciers"
@@ -1562,19 +1588,19 @@ msgstr "Mëttelalter"
 
 #: lu_ext_wms.395
 msgid "Temps modernes"
-msgstr ""
+msgstr "Temps modernes"
 
 #: lu_ext_wms.396
 msgid "Epoque indefinie"
-msgstr ""
+msgstr "Epoque indéfinie"
 
 #: lu_ext_wms.397
 msgid "Protohistoire"
-msgstr ""
+msgstr "Protohistoire"
 
 #: lu_ext_wms.398
 msgid "Gallo-Romain"
-msgstr ""
+msgstr "Gallo-Romain"
 
 #: lu_int_wms.399
 msgid "anf_arbres_remarquables"
@@ -1626,7 +1652,7 @@ msgstr "SP Logement"
 
 #: lu_int_wms.411
 msgid "at_psl1"
-msgstr "Zonen fir gréisser Wunnengsbauprojeten"
+msgstr "Zonen fir gréisser Wunnéngsbauprojeten"
 
 #: lu_int_wms.412
 msgid "at_pszae2"
@@ -1634,7 +1660,7 @@ msgstr "Nei Aktivitéitszonen an Erweiderungen"
 
 #: lu_int_wms.413
 msgid "at_pszae3"
-msgstr "Bestehend Aktivitéitszonen fir Emzeklasséieren"
+msgstr "Bestehend Aktivitéitszonen fir ëmzeklasséieren"
 
 #: lu_int_wms.414
 msgid "at_pszae4"
@@ -1694,7 +1720,7 @@ msgstr "Remembrementsperimeter"
 
 #: lu_int_wms.428
 msgid "repere_alti"
-msgstr ""
+msgstr "Héichtebolzen"
 
 #: l_wmts.429
 msgid "eau_new_HQ100_(mittlere_Wahrscheinlichkeit)"
@@ -1734,7 +1760,7 @@ msgstr "PRE"
 
 #: lu_int_wms.438
 msgid "pag_lintgen_layer"
-msgstr ""
+msgstr "Plan d'aménagement vun der Gemeng Lëntgen"
 
 #: group.439
 msgid "eau_new_Projekt_TIMIS_(usage_interne)"
@@ -1742,7 +1768,7 @@ msgstr "Projet TIMIS"
 
 #: group.440
 msgid "group_lenoz"
-msgstr ""
+msgstr "Lenoz"
 
 #: lu_int_wms.441
 msgid "at_pst3"
@@ -1762,7 +1788,7 @@ msgstr "Grondwaasser 2009"
 
 #: lu_int_wms.445
 msgid "MO"
-msgstr ""
+msgstr "Mensuration Officielle"
 
 #: l_wmts.446
 msgid "sections_cadastrales_labels_eau"
@@ -1786,7 +1812,7 @@ msgstr "Chemeschen Zoustand vun de WK 2009"
 
 #: lu_int_wms.451
 msgid "env_corridors"
-msgstr ""
+msgstr "Corridors"
 
 #: lu_int_wms.452
 msgid "env_iba"
@@ -1822,7 +1848,7 @@ msgstr "Gewässernetz"
 
 #: group.460
 msgid "eau_new_Fischerei"
-msgstr "Fëschereidëngscht"
+msgstr "Fëschereidéngscht"
 
 #: group.461
 msgid "eau_new_Projekt_Hochwasserrisikokarten_2013"
@@ -1838,11 +1864,11 @@ msgstr "Kadasterparzellen"
 
 #: group.464
 msgid "olos_group"
-msgstr ""
+msgstr "Parcelles OLOS"
 
 #: lu_int_wms.466
 msgid "topo_decoupage_5000_ed2015"
-msgstr ""
+msgstr "Blatschnëtt topographesche Plang 1:5000 Editioun 2015"
 
 #: group.467
 msgid "eau_new_Risikobeurteilung_2021"
@@ -1878,7 +1904,7 @@ msgstr "Miessstatiounen [WRRL]"
 
 #: group.475
 msgid "eau_new_Qualitaetskomponenten_des_oekologischen_Zustands_2015"
-msgstr "Qualitéitskomponente vum ökologeschen Zustandes 2015"
+msgstr "Qualitéitskomponente vum ökologeschen Zoustand 2015"
 
 #: group.476
 msgid "eau_new_Grundwasser_2021"
@@ -1902,7 +1928,7 @@ msgstr "Grondwaasser 2015"
 
 #: group.481
 msgid "eau_new_Oberflaechengewaesser_Messstationen"
-msgstr "Messstatiounen Iwwerflächegewässer"
+msgstr "Miessstatiounen Iwwerflächegewässer"
 
 #: group.482
 msgid "eau_new_Grundwasser_Messstationen"
@@ -1998,7 +2024,7 @@ msgstr "Natur & Ausflich"
 
 #: lu_int_wms.505
 msgid "lenoz_lmg"
-msgstr ""
+msgstr "Liewensmëttelgeschäfter"
 
 #: lu_int_wms.506
 msgid "lenoz_ecoles_old"
@@ -2022,7 +2048,7 @@ msgstr "Family & Kids"
 
 #: lu_int_wms.511
 msgid "buildings_go"
-msgstr "Gebeier"
+msgstr "Gebaier"
 
 #: lu_int_wms.512
 msgid "parcels_labels_go"
@@ -2042,7 +2068,7 @@ msgstr "«Pickup»-Statiounen"
 
 #: lu_int_wms.516
 msgid "asta_flik_parcels_2015_prof"
-msgstr "Map Quest"
+msgstr "FLIK Parzellen vun der ASTA Versioun 2015"
 
 #: lu_int_wms.517
 msgid "lenoz_Banken"
@@ -2062,7 +2088,7 @@ msgstr ""
 
 #: group.521
 msgid "asta_esp_group"
-msgstr "Ökologisch wertvolle Flächen "
+msgstr "Ökologesch wäertvoll Flächen "
 
 #: lu_int_wms.522
 msgid "lenoz_Ärzte"
@@ -2118,7 +2144,7 @@ msgstr "Vereinfacht Kaart vun den natiirlechen Bëscher"
 
 #: group.535
 msgid "bglayers"
-msgstr "Hannergrond Layer"
+msgstr "Hannergrondlayer"
 
 #: l_wmts.536
 msgid "topogr_global"
@@ -2138,7 +2164,7 @@ msgstr ""
 
 #: lu_ext_wms.540
 msgid "tour_pistes_velo_mymaps2"
-msgstr "Regional Velosweeër"
+msgstr "Regional Vëlosweeër"
 
 #: lu_ext_wms.541
 msgid "projets_amen"
@@ -2194,7 +2220,7 @@ msgstr "Drénkwaassersyndikater"
 
 #: lu_int_wms.554
 msgid "eau_new_Zones_interdiction_utilisation_metazachlore"
-msgstr "Gebidder an deenen et verbueden ass Metazachlor auszebréngen"
+msgstr "Gebidder an denen et verbueden ass Metazachlor auszebréngen"
 
 #: lu_int_wms.555
 msgid "editus_poi_299"
@@ -2214,11 +2240,11 @@ msgstr "Handel"
 
 #: lu_int_wms.559
 msgid "editus_poi_289"
-msgstr "Kommunikatioun an Multimedia"
+msgstr "Kommunikatioun a Multimedia"
 
 #: lu_int_wms.560
 msgid "editus_poi_290"
-msgstr "Kultur, Fräizäit a Turissem"
+msgstr "Kultur, Fräizäit an Turissem"
 
 #: lu_int_wms.561
 msgid "editus_poi_294"
@@ -2250,7 +2276,7 @@ msgstr "Déngschtleeschtung fir Professionneller"
 
 #: group.568
 msgid "editus_pois"
-msgstr "Points d'intérêt Editus"
+msgstr "Editus Punkten"
 
 #: l_wmts.569
 msgid "basemap_2015_global"
@@ -4346,7 +4372,7 @@ msgstr "Geforeklassen"
 
 #: lu_int_wms.1090
 msgid "eau_new_Stausee_Sauer"
-msgstr "Öewersauer-Stauséi"
+msgstr "Uewersauer-Stauséi"
 
 #: lu_int_wms.1091
 msgid "eau_new_Grundwasser_(Nitratrichtlinie)"
@@ -4362,7 +4388,7 @@ msgstr "Aschränkungen Wärmepompelen"
 
 #: lu_int_wms.1094
 msgid "eau_new_ZPS_durch_grosshrzgl._Verordnung_festgelegt"
-msgstr "ZPS duerch grousshrzgl. reglement festgeluecht"
+msgstr "ZPS duerch grousshrzgl. Reglement festgeluecht"
 
 #: lu_int_wms.1095
 msgid "eau_new_Intensitaet_-_HQ_100_(usage_interne)"
@@ -5827,7 +5853,7 @@ msgstr "Staark modifizéiert OWK 2009"
 
 #: lu_int_wms.1459
 msgid "eau_new_Natuerliche_(Bassin)_(usage_interne)"
-msgstr "Natierleche Baseng"
+msgstr "Natierleche Baséng"
 
 #: lu_int_wms.1460
 msgid "eau_new_Einzugsgebiete"
@@ -5899,7 +5925,7 @@ msgstr ""
 
 #: lu_int_wms.1477
 msgid "eau_new_Alluvialer_Grundwasserspiegel"
-msgstr "Alluvialen Grondwaasserspigel"
+msgstr "Alluvialen Grondwaasserspijel"
 
 #: lu_int_wms.1478
 msgid "eau_new_Nitratrichtlinie_Messstationen"

--- a/geoportailv3/locale/lb/LC_MESSAGES/geoportailv3-server.po
+++ b/geoportailv3/locale/lb/LC_MESSAGES/geoportailv3-server.po
@@ -5,98 +5,96 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: portail\n"
-"POT-Creation-Date: 2015-01-16 16:16+0100\n"
-"PO-Revision-Date: 2015-01-21 08:17+0000\n"
-"Last-Translator: Stéphane Brunner <stephane.brunner@camptocamp.com>\n"
-"Language-Team: Luxembourgish (http://www.transifex.com/projects/p/"
-"geoportailv3-lu/language/lb/)\n"
-"Language: lb\n"
+"PO-Revision-Date: 2015-07-10 13:47+0000\n"
+"Last-Translator: patrick weber <pweber@spatialbit.com>\n"
+"Language-Team: Luxembourgish (http://www.transifex.com/p/geoportailv3-lu/language/lb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Lingua 3.8\n"
+"Language: lb\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: geoportailv3/models.py:21
+#: ./geoportailv3/models.py:21
 msgid "Internal WMS layer"
 msgstr ""
 
-#: geoportailv3/models.py:22
+#: ./geoportailv3/models.py:22
 msgid "Internal WMS layers"
 msgstr ""
 
-#: geoportailv3/models.py:43
+#: ./geoportailv3/models.py:43
 msgid "External WMS layer"
 msgstr ""
 
-#: geoportailv3/models.py:44
+#: ./geoportailv3/models.py:44
 msgid "External WMS layers"
 msgstr ""
 
-#: geoportailv3/models.py:35
+#: ./geoportailv3/models.py:35
 msgid "Url"
 msgstr ""
 
-#: geoportailv3/models.py:36
+#: ./geoportailv3/models.py:36
 msgid "Layers"
 msgstr "Couchen"
 
-#: geoportailv3/models.py:37
+#: ./geoportailv3/models.py:37
 msgid "Is a POI"
 msgstr ""
 
-#: geoportailv3/models.py:38
+#: ./geoportailv3/models.py:38
 msgid "Collection ID"
 msgstr ""
 
-#: geoportailv3/models.py:39
+#: ./geoportailv3/models.py:39
 msgid "REST url"
 msgstr ""
 
-#: geoportailv3/models.py:57
+#: ./geoportailv3/models.py:57
 msgid "Category ID"
 msgstr ""
 
-#: geoportailv3/models.py:68
+#: ./geoportailv3/models.py:68
 msgid "Table name"
 msgstr ""
 
-#: geoportailv3/models.py:69
+#: ./geoportailv3/models.py:69
 msgid "URL Rest"
 msgstr ""
 
-#: geoportailv3/models.py:70
+#: ./geoportailv3/models.py:70
 msgid "Engine"
 msgstr ""
 
-#: geoportailv3/models.py:71
-#, fuzzy
+#: ./geoportailv3/models.py:71
 msgid "Layer"
-msgstr "Couchen"
+msgstr ""
 
-#: geoportailv3/models.py:72
+#: ./geoportailv3/models.py:72
 msgid "Template file name"
 msgstr ""
 
-#: geoportailv3/models.py:74
+#: ./geoportailv3/models.py:74
 msgid "Is the template local or remote"
 msgstr ""
 
-#: geoportailv3/models.py:75
+#: ./geoportailv3/models.py:75
 msgid "Python function"
 msgstr ""
 
-#: geoportailv3/models.py:76
+#: ./geoportailv3/models.py:76
 msgid "Role"
 msgstr ""
 
-#: geoportailv3/models.py:77
+#: ./geoportailv3/models.py:77
 msgid "Attributes to keep"
 msgstr ""
 
-#: geoportailv3/models.py:78
+#: ./geoportailv3/models.py:78
 msgid "Id of the poi collection"
 msgstr ""
 
-#: geoportailv3/models.py:79
+#: ./geoportailv3/models.py:79
 msgid "Geometry column name"
 msgstr ""

--- a/geoportailv3/static/js/exclusionmanagerservice.js
+++ b/geoportailv3/static/js/exclusionmanagerservice.js
@@ -45,25 +45,11 @@ app.ExclusionManager = function(gettextCatalog, ngeoBackgroundLayerMgr,
   this.notify_ = appNotify;
 
   /**
-   * @type {function(string, Object<string, *>): string}
+   * @type {angularGettext.Catalog}
    * @private
    */
-  this.translate_ = goog.bind(gettextCatalog.getString, gettextCatalog);
+  this.gettextCatalog_ = gettextCatalog;
 
-  /**
-   * @type {string}
-   * @private
-   */
-  this.exclusionMessage1_ = 'Background has been deactivated because the ' +
-      'layer {{layer}} cannot be displayed on top of it.';
-
-  /**
-   * @type {string}
-   * @private
-   */
-  this.exclusionMessage2_ = 'The layer(s) <b>{{layersToRemove}}</b> have ' +
-      ' been removed because they cannot be displayed while the layer ' +
-      '<b>{{layer}}</b> is displayed';
 };
 
 
@@ -116,7 +102,7 @@ app.ExclusionManager.prototype.checkForLayerExclusion_ = function(map, layer1) {
   var i;
   var layer2;
   var msg;
-
+  var gettextCatalog = this.gettextCatalog_;
   var layersToRemove = [];
   for (i = len - 1; i >= 0; i--) {
     layer2 = layers[i];
@@ -131,22 +117,38 @@ app.ExclusionManager.prototype.checkForLayerExclusion_ = function(map, layer1) {
     if (this.intersects_(exclusion1, exclusion2) && opacity > 0) {
       // layer to exclude is not the current base layer
       if (i !== 0) {
-        layersToRemove.push(layer2.get('label'));
+        layersToRemove.push(
+            gettextCatalog.getString(/** @type {string} */(layer2.get('label')))
+        );
         map.removeLayer(layer2);
       } else {
         this.backgroundLayerMgr_.set(map, this.blankLayer_);
-        msg = this.translate_(this.exclusionMessage1_, {
-          'layer': '<b>' + layer1.get('label') + '</b>'
-        });
+        msg = gettextCatalog.getString(
+            'Background has been deactivated because ' +
+            'the layer {{layer}} cannot be displayed on top of it.',
+            {
+              'layer': gettextCatalog.getString(
+                  /** @type {string} */(layer1.get('label')))
+            }
+            );
         this.notify_(msg);
       }
     }
   }
   if (layersToRemove.length) {
-    msg = this.translate_(this.exclusionMessage2_, {
-      'layersToRemove': '<b>' + layersToRemove.join(', ') + '</b>',
-      'layer': '<b>' + layer1.get('label') + '</b>'
-    });
+    msg = gettextCatalog.getPlural(
+        layersToRemove.length,
+        'The layer <b>{{layersToRemove}}</b> ' +
+        'has been removed because it cannot be displayed while the layer ' +
+        '<b>{{layer}}</b> is displayed',
+        'The layers <b>{{layersToRemove}}</b> ' +
+        'have been removed because they cannot be displayed while the layer ' +
+        '<b>{{layer}}</b> is displayed',
+        {
+          'layersToRemove': layersToRemove.join(', '),
+          'layer': gettextCatalog.getString(
+              /** @type {string} */(layer1.get('label')))
+        });
     this.notify_(msg);
   }
 };

--- a/geoportailv3/static/js/notifyservice.js
+++ b/geoportailv3/static/js/notifyservice.js
@@ -32,7 +32,7 @@ app.notifyFactory = function() {
 
     window.setTimeout(function() {
       el.alert('close');
-    }, 5000);
+    }, 7000);
   }
 };
 

--- a/geoportailv3/static/js/share/sharedirective.js
+++ b/geoportailv3/static/js/share/sharedirective.js
@@ -40,10 +40,11 @@ app.module.directive('appShare', app.shareDirective);
  * @ngInject
  * @constructor
  * @param {angular.$window} $window
+ * @param {gettext} gettext
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
  * @export
  */
-app.ShareDirectiveController = function($window, gettextCatalog) {
+app.ShareDirectiveController = function($window, gettext, gettextCatalog) {
   /**
    * @type {Object}
    * @private
@@ -106,7 +107,7 @@ app.ShareDirectiveController.prototype.openMailLink = function() {
   googUri.setScheme('mailto');
   googUri.setQueryData(goog.Uri.QueryData.createFromMap({
     'subject': this.window_.document.title +
-        this.translate_.getString(' - link from geoportail.lu'),
+        this.translate_.getString(gettext(' - link from geoportail.lu')),
     'body': this.window_.location.href
   }));
   this.window_.open(googUri.toString(), '_self', this.windowOptions_);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "angular": "1.4.1",
     "angular-gettext": "2.1.0",
-    "angular-gettext-tools": "1.0.4",
+    "angular-gettext-tools": "2.1.2",
     "bootstrap": "^3.3.0",
     "font-awesome": "4.2.0",
     "jquery": "^1.9.1",


### PR DESCRIPTION
The angular gettext translation string extractor simply does string matching for finding translation strings.
This means that renamed methods such as `this.translate_` wont work for string extraction. 
````
this.translate_ = gettextCatalog;

gettextCatalog.getString('string1'); // gets extracted
gettext('string2'); // gets extracted
gettextCatalog.getPlural(n, 'singular', 'plural'); // gets extracted correctly as one single/plural pair string

var string3 = 'string3'; // string does not get extracted
gettextCatalog.getString(string3) // will not be translated as string is not extracted
this.translate_.getString(string3) // will not be translated

var string4 = gettext('string4'); // string gets extracted
gettextCatalog.getString(string4) // will be translated as string is extracted 
this.translate_.getString(string4) // will be translated
````

