### PR TITLE
Do not query the map while dragging the map

### DIFF
--- a/geoportailv3/static/js/query/querydirective.js
+++ b/geoportailv3/static/js/query/querydirective.js
@@ -254,8 +254,8 @@ app.QueryController = function($sce, $timeout, $scope, $http,
 
   goog.events.listen(this.map_, ol.MapBrowserEvent.EventType.POINTERMOVE,
       function(evt) {
-        if (this.isQuerying_) {
-          return false;
+        if (evt.dragging || this.isQuerying_) {
+          return;
         }
         if (!this['queryActive']) {
           this.map_.getTargetElement().style.cursor = '';


### PR DESCRIPTION
`map.forEachLayerAtPixel()` is a costly operation. We should not do that operation while the map is being dragged.

This makes panning the map much faster for me on FF Linux. And it should improve the pan performance in other browsers as well.

Please review.

Fixes #769.