### PR TITLE
Use typeahead.js 0.11.1

### DIFF
--- a/geoportailv3/static/js/search/searchdirective.js
+++ b/geoportailv3/static/js/search/searchdirective.js
@@ -284,7 +284,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
     source: goog.bind(function(query, syncResults) {
       return syncResults(this.matchCoordinate_(query));
     }, this),
-    displayKey: function(suggestion) {
+    display: function(suggestion) {
       var feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label');
     },
@@ -314,7 +314,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
      * @param {Object} suggestion
      * @return {string}
      */
-    displayKey: function(suggestion) {
+    display: function(suggestion) {
       return suggestion['translatedName'];
     },
     templates: /** @type {TypeaheadTemplates} */({
@@ -350,7 +350,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
      * @param {app.BackgroundLayerSuggestion} suggestion
      * @return {string}
      */
-    displayKey: function(suggestion) {
+    display: function(suggestion) {
       return suggestion['translatedName'];
     },
     templates: /** @type {TypeaheadTemplates} */({
@@ -375,7 +375,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
   },{
     name: 'pois',
     source: POIBloodhoundEngine.ttAdapter(),
-    displayKey: function(suggestion) {
+    display: function(suggestion) {
       var feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label');
     },

--- a/geoportailv3/static/js/search/searchdirective.js
+++ b/geoportailv3/static/js/search/searchdirective.js
@@ -375,6 +375,9 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
   },{
     name: 'pois',
     source: POIBloodhoundEngine.ttAdapter(),
+    // Use a large number for "limit" here. This is to work around a bug
+    // in typeahead.js: https://github.com/twitter/typeahead.js/pull/1319
+    limit: 50,
     display: function(suggestion) {
       var feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label');

--- a/geoportailv3/static/less/search.less
+++ b/geoportailv3/static/less/search.less
@@ -35,7 +35,7 @@ span.twitter-typeahead {
         padding-left: 32px;
         width: auto;
     }
-    .tt-dropdown-menu {
+    .tt-menu {
         position: absolute;
         top: 100%;
         left: 0;
@@ -56,7 +56,7 @@ span.twitter-typeahead {
         box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
         background-clip: padding-box;
     }
-    .tt-suggestion > p {
+    .tt-suggestion {
         display: block;
         padding: 3px 20px;
         margin-bottom: 0px;
@@ -134,7 +134,7 @@ span.twitter-typeahead {
         width: 100%;
       }
 
-      span.twitter-typeahead .tt-dropdown-menu {
+      span.twitter-typeahead .tt-menu {
         width: 100%;
       }
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "openlayers": "git+https://github.com/openlayers/ol3#master",
     "proj4": "2.3.3",
     "phantomjs": "~1.9.7-5",
-    "typeahead.js": "~0.10.5",
+    "typeahead.js": "0.11.1",
     "temp": "~0.7.0",
     "walk": "~2.3.3",
     "d3": "3.5.5",


### PR DESCRIPTION
We're [updating](https://github.com/camptocamp/ngeo/pull/283) ngeo with version 0.11.1 of typeahead.js. This PR accommodates this update.

Please review and test.

When reviewed and tested I'll merge https://github.com/camptocamp/ngeo/pull/283 and this PR.