### PR TITLE
Use closure-compiler commit 5ff0611 for externs

### DIFF
--- a/CONST_Makefile
+++ b/CONST_Makefile
@@ -513,22 +513,22 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 
 .build/externs/angular-1.4.js:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.4.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/5ff0611/contrib/externs/angular-1.4.js
 	touch $@
 
 .build/externs/angular-1.4-q_templated.js:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.4-q_templated.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/5ff0611/contrib/externs/angular-1.4-q_templated.js
 	touch $@
 
 .build/externs/angular-1.4-http-promise_templated.js:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/angular-1.4-http-promise_templated.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/5ff0611/contrib/externs/angular-1.4-http-promise_templated.js
 	touch $@
 
 .build/externs/jquery-1.9.js:
 	mkdir -p $(dir $@)
-	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/master/contrib/externs/jquery-1.9.js
+	wget -O $@ https://raw.githubusercontent.com/google/closure-compiler/5ff0611/contrib/externs/jquery-1.9.js
 	touch $@
 
 package.json:


### PR DESCRIPTION
Recent updates to the angular-1.4 externs cause the following compilation error:

```
ERR! compile .build/externs/angular-1.4.js:2234: ERROR - Bad type annotation.  missing closing )
ERR! compile * @typedef {function(Function, number=, boolean=, ...=):!angular.$q.Promise}
```

Fixing the problem requires using a more recent version of Closure Compiler. There's https://github.com/openlayers/closure-util/pull/67, but it's not merged yet. In the mean time this commit uses a specific commit when downloading the closure-compiler externs.

Fixes #840.