### PR TITLE
Remove one-time binding in catalog

### DIFF
--- a/geoportailv3/static/js/catalog/layertree.html
+++ b/geoportailv3/static/js/catalog/layertree.html
@@ -15,7 +15,7 @@
 </div>
 <ul id="catalog-{{::layertreeCtrl.uid}}" ng-if="::layertreeCtrl.node.children"
   ng-class="{collapse: !layertreeCtrl.isRoot && layertreeCtrl.depth < 3, catalog: layertreeCtrl.isRoot}">
-  <li ng-repeat="node in ::layertreeCtrl.node.children"
+  <li ng-repeat="node in layertreeCtrl.node.children"
       ngeo-layertree="node"
       ngeo-layertree-notroot
       ngeo-layertree-map="layertreeCtrl.map"


### PR DESCRIPTION
This fixes a regression introduced by d42e5a4, where the catalog tree is not updated when switching themes. This commit removes the use of one-time binding that causes that problem.

Fixes #837.