### PR TITLE
Switch back to typeahead 0.10.5

### DIFF
--- a/build.json
+++ b/build.json
@@ -27,6 +27,7 @@
       ".build/externs/angular-1.4-http-promise_templated.js",
       "geoportailv3/externs/fuse.js",
       "geoportailv3/externs/twbootstrap.js",
+      "geoportailv3/externs/typeahead.js",
       ".build/externs/jquery-1.9.js"
     ],
     "define": [

--- a/geoportailv3/externs/typeahead.js
+++ b/geoportailv3/externs/typeahead.js
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Extern definitions for typeahead.
+ * @externs
+ */
+
+
+/**
+ * displayKey was replaced by display in typeahead v0.11.1. So we need this
+ * extra extern definition so long that we use v0.10.5.
+ * @type {string|undefined}
+ */
+TypeaheadDataset.prototype.displayKey;

--- a/geoportailv3/static/js/search/searchdirective.js
+++ b/geoportailv3/static/js/search/searchdirective.js
@@ -285,7 +285,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
     source: goog.bind(function(query, syncResults) {
       return syncResults(this.matchCoordinate_(query));
     }, this),
-    display: function(suggestion) {
+    displayKey: function(suggestion) {
       var feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label');
     },
@@ -315,7 +315,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
      * @param {Object} suggestion
      * @return {string}
      */
-    display: function(suggestion) {
+    displayKey: function(suggestion) {
       return suggestion['translatedName'];
     },
     templates: /** @type {TypeaheadTemplates} */({
@@ -351,7 +351,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
      * @param {app.BackgroundLayerSuggestion} suggestion
      * @return {string}
      */
-    display: function(suggestion) {
+    displayKey: function(suggestion) {
       return suggestion['translatedName'];
     },
     templates: /** @type {TypeaheadTemplates} */({
@@ -376,7 +376,7 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
   },{
     name: 'pois',
     source: POIBloodhoundEngine.ttAdapter(),
-    display: function(suggestion) {
+    displayKey: function(suggestion) {
       var feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label');
     },

--- a/geoportailv3/static/js/search/searchdirective.js
+++ b/geoportailv3/static/js/search/searchdirective.js
@@ -376,9 +376,6 @@ app.SearchDirectiveController = function($scope, $compile, gettextCatalog,
   },{
     name: 'pois',
     source: POIBloodhoundEngine.ttAdapter(),
-    // Use a large number for "limit" here. This is to work around a bug
-    // in typeahead.js: https://github.com/twitter/typeahead.js/pull/1319
-    limit: 50,
     display: function(suggestion) {
       var feature = /** @type {ol.Feature} */ (suggestion);
       return feature.get('label');

--- a/geoportailv3/static/less/search.less
+++ b/geoportailv3/static/less/search.less
@@ -35,7 +35,7 @@ span.twitter-typeahead {
         padding-left: 32px;
         width: auto;
     }
-    .tt-menu {
+    .tt-dropdown-menu {
         position: absolute;
         top: 100%;
         left: 0;
@@ -56,7 +56,7 @@ span.twitter-typeahead {
         box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
         background-clip: padding-box;
     }
-    .tt-suggestion {
+    .tt-suggestion > p {
         display: block;
         padding: 3px 20px;
         margin-bottom: 0px;
@@ -134,7 +134,7 @@ span.twitter-typeahead {
         width: 100%;
       }
 
-      span.twitter-typeahead .tt-menu {
+      span.twitter-typeahead .tt-dropdown-menu {
         width: 100%;
       }
     }

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -248,7 +248,7 @@
     <script src="${request.static_url('%s/ngeo/utils/watchwatchers.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/proj4/dist/proj4-src.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/d3/d3.min.js' % node_modules_path)}"></script>
-    <script src="${request.static_url('%s/typeahead.js/dist/typeahead.bundle.min.js' % node_modules_path)}"></script>
+    <script src="${request.static_url('%s/typeahead.js/dist/typeahead.bundle.js' % node_modules_path)}"></script>
     <script src="${request.static_url('%s/fuse.js/src/fuse.js' % node_modules_path)}"></script>
 % else:
     <script src="${request.static_url('geoportailv3:static/build/build.js')}"></script>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "openlayers": "git+https://github.com/openlayers/ol3#master",
     "proj4": "2.3.3",
     "phantomjs": "~1.9.7-5",
-    "typeahead.js": "0.11.1",
+    "typeahead.js": "~0.10.5",
     "temp": "~0.7.0",
     "walk": "~2.3.3",
     "d3": "3.5.5",


### PR DESCRIPTION
This reverts the upgrade to typeahead 0.11.1. See #839 for details on why this revert is necessary.

Fixes #839. 