### PR TITLE
migrate to typehead 0.11.1

### DIFF
--- a/geoportailv3/static/less/search.less
+++ b/geoportailv3/static/less/search.less
@@ -35,7 +35,7 @@ span.twitter-typeahead {
         padding-left: 32px;
         width: auto;
     }
-    .tt-dropdown-menu {
+    .tt-menu {
         position: absolute;
         top: 100%;
         left: 0;
@@ -56,7 +56,7 @@ span.twitter-typeahead {
         box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
         background-clip: padding-box;
     }
-    .tt-suggestion > p {
+    .tt-suggestion {
         display: block;
         padding: 3px 20px;
         margin-bottom: 0px;
@@ -68,16 +68,12 @@ span.twitter-typeahead {
         strong {
             font-weight: 900;
         }
-        :hover, :focus {
+        &.tt-cursor, &:hover, &:focus {
             color: #ffffff;
             text-decoration: none;
             outline: 0;
             background-color: #428bca;
         }
-    }
-    .tt-suggestion.tt-cursor {
-        color: #ffffff;
-        background-color: #428bca;
     }
     .tt-suggestion button {
         background: none;
@@ -134,7 +130,7 @@ span.twitter-typeahead {
         width: 100%;
       }
 
-      span.twitter-typeahead .tt-dropdown-menu {
+      span.twitter-typeahead .tt-menu {
         width: 100%;
       }
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "openlayers": "git+https://github.com/openlayers/ol3#master",
     "proj4": "2.3.3",
     "phantomjs": "~1.9.7-5",
-    "typeahead.js": "~0.10.5",
+    "typeahead.js": "0.11.1",
     "temp": "~0.7.0",
     "walk": "~2.3.3",
     "d3": "3.5.5",


### PR DESCRIPTION
Could you please review.

My biggest problem was the fact that dataset is no more transmitted to the selected event. 
The way I've used to solved that problem is putting the dataset name into each result. 
But unfortunately, I can't do that here https://github.com/Geoportail-Luxembourg/geoportailv3/blob/fix_search/geoportailv3/static/js/search/searchdirective.js#L383

Probably not perfect but it seems to work. If you have any clues to improve that, you are welcome.

FYI This is no more correct : 
https://github.com/camptocamp/ngeo/blob/master/externs/ngeox.js#L315,L316