### PR TITLE
Permalink feature encoding/decoding

### DIFF
--- a/geoportailv3/static/js/draw/drawdirective.js
+++ b/geoportailv3/static/js/draw/drawdirective.js
@@ -16,6 +16,7 @@ goog.provide('app.DrawController');
 goog.provide('app.drawDirective');
 
 goog.require('app');
+goog.require('ngeo.DecorateInteraction');
 goog.require('ol.events.condition');
 goog.require('ol.geom.GeometryType');
 goog.require('ol.interaction.Draw');


### PR DESCRIPTION
This PR changes the draw directive to encode drawn features in the URL. At init time the directive also decodes the features set in the URL and adds them to the collection of drawn features.

Two things to note:

* At this point features are not added to the local storage. I don't think this is something we've discussed yet.
* #845 is not implemented yet, as there is no notion of mymaps map in the code at this point.