### PR TITLE
Fix feature encoding/decoding issues

### DIFF
--- a/geoportailv3/static/js/draw/drawdirective.js
+++ b/geoportailv3/static/js/draw/drawdirective.js
@@ -129,7 +129,9 @@ app.DrawController = function($scope, ngeoDecorateInteraction, ngeoLocation,
    * @type {ngeo.format.FeatureHash}
    * @private
    */
-  this.fhFormat_ = new ngeo.format.FeatureHash();
+  this.fhFormat_ = new ngeo.format.FeatureHash({
+    encodeStyles: false
+  });
 
   /**
    * @type {ol.FeatureStyleFunction}

--- a/geoportailv3/static/js/draw/drawdirective.js
+++ b/geoportailv3/static/js/draw/drawdirective.js
@@ -130,7 +130,19 @@ app.DrawController = function($scope, ngeoDecorateInteraction, ngeoLocation,
    * @private
    */
   this.fhFormat_ = new ngeo.format.FeatureHash({
-    encodeStyles: false
+    encodeStyles: false,
+    properties: (
+        /**
+         * @param {ol.Feature} feature Feature.
+         * @return {Object.<string, (string|number)>} Properties to encode.
+         */
+        function(feature) {
+          // Do not encode the __editable__ and __selected__ properties.
+          var properties = feature.getProperties();
+          delete properties['__editable__'];
+          delete properties['__selected__'];
+          return properties;
+        })
   });
 
   /**

--- a/geoportailv3/static/js/draw/drawdirective.js
+++ b/geoportailv3/static/js/draw/drawdirective.js
@@ -227,15 +227,6 @@ app.DrawController = function($scope, ngeoDecorateInteraction, ngeoLocation,
     }
   }, this));
 
-  // Decode the features encoded in the URL and add them to the collection
-  // of drawn features.
-  var encodedFeatures = ngeoLocation.getParam('features');
-  if (goog.isDef(encodedFeatures)) {
-    var features = this.fhFormat_.readFeatures(encodedFeatures);
-    goog.asserts.assert(!goog.isNull(features));
-    this.drawnFeatures_.extend(features);
-  }
-
   var selectInteraction = new ol.interaction.Select({
     features: appSelectedFeatures,
     filter: goog.bind(function(feature, layer) {
@@ -294,6 +285,38 @@ app.DrawController = function($scope, ngeoDecorateInteraction, ngeoLocation,
 
   var drawOverlay = ngeoFeatureOverlayMgr.getFeatureOverlay();
   drawOverlay.setFeatures(appDrawnFeatures);
+
+  this.drawFeaturesInUrl_();
+};
+
+
+/**
+ * Decode the features encoded in the URL and add them to the collection
+ * of drawn features.
+ * @private
+ */
+app.DrawController.prototype.drawFeaturesInUrl_ = function() {
+  var encodedFeatures = this.ngeoLocation_.getParam('features');
+  if (goog.isDef(encodedFeatures)) {
+    var features = this.fhFormat_.readFeatures(encodedFeatures);
+    goog.asserts.assert(!goog.isNull(features));
+    for (var i = 0; i < features.length; ++i) {
+      var feature = features[i];
+      var opacity = /** @type {string} */ (feature.get('opacity'));
+      feature.set('opacity', +opacity);
+      var stroke = /** @type {string} */ (feature.get('stroke'));
+      feature.set('stroke', +stroke);
+      var size = /** @type {string} */ (feature.get('size'));
+      feature.set('size', +size);
+      var angle = /** @type {string} */ (feature.get('angle'));
+      feature.set('angle', +angle);
+      var isLabel = /** @type {string} */ (feature.get('is_label'));
+      feature.set('is_label', isLabel === 'true');
+      feature.set('__editable__', true);
+      feature.setStyle(this.featureStyleFunction_);
+    }
+    this.drawnFeatures_.extend(features);
+  }
 };
 
 

--- a/geoportailv3/static/js/draw/drawdirective.js
+++ b/geoportailv3/static/js/draw/drawdirective.js
@@ -131,6 +131,12 @@ app.DrawController = function($scope, ngeoDecorateInteraction, ngeoLocation,
    */
   this.fhFormat_ = new ngeo.format.FeatureHash();
 
+  /**
+   * @type {ol.FeatureStyleFunction}
+   * @private
+   */
+  this.featureStyleFunction_ = app.DrawController.createStyleFunction_();
+
   var drawPoint = new ol.interaction.Draw({
     features: this.drawnFeatures_,
     type: ol.geom.GeometryType.POINT
@@ -304,7 +310,7 @@ app.DrawController.prototype.onDrawEnd_ = function(event) {
   feature.set('is_label', false);
   feature.set('linestyle', 'plain');
   feature.set('symbol_id', 'circle');
-  feature.setStyle(app.DrawController.createStyleFunction_());
+  feature.setStyle(this.featureStyleFunction_);
 
   // Deactivating asynchronosly to prevent dbl-click to zoom in
   window.setTimeout(goog.bind(function() {
@@ -322,6 +328,7 @@ app.DrawController.prototype.onDrawEnd_ = function(event) {
   this.ngeoLocation_.updateParams({
     'features': this.fhFormat_.writeFeatures(features)
   });
+
   this.selectedFeatures_.clear();
   this.selectedFeatures_.push(feature);
   this.featurePopup_.show(feature);

--- a/geoportailv3/static/js/draw/drawdirective.js
+++ b/geoportailv3/static/js/draw/drawdirective.js
@@ -79,13 +79,13 @@ app.DrawController = function($scope, ngeoDecorateInteraction, ngeoLocation,
 
   /**
    * @type {ol.Map}
-   *  @export
+   * @export
    */
   this.map;
 
   /**
    * @type {boolean}
-   *  @export
+   * @export
    */
   this.active;
 


### PR DESCRIPTION
This PR fixes a number of feature URL encoding/decoding issues:

- encode the feature style properties instead of encoding the feature styles
- do not encode internal properties such as `__editable__`
- give decoded features correct style values (with correct types)
- re-encode features on feature change

Requires https://github.com/camptocamp/ngeo/pull/323.