### PR TITLE
Do not use checkStructDictInheritance

### DIFF
--- a/build.json
+++ b/build.json
@@ -48,7 +48,6 @@
       "ambiguousFunctionDecl",
       "checkEventfulObjectDisposal",
       "checkRegExp",
-      "checkStructDictInheritance",
       "checkTypes",
       "checkVars",
       "const",


### PR DESCRIPTION
This compile option does not exist anymore. And we get a compile error when using a recent version of the compiler.