### PR TITLE
Set TEMPLATE_EXCLUDE in elemoine.mk

### DIFF
--- a/elemoine.mk
+++ b/elemoine.mk
@@ -7,6 +7,8 @@ PRINT_OUTPUT = tomcat
 TOMCAT_STOP_COMMAND =
 TOMCAT_START_COMMAND =
 
+TEMPLATE_EXCLUDE = $(PRINT_OUTPUT)
+
 include geoportailv3.mk
 
 .PHONY: dbtunnel


### PR DESCRIPTION
This is to prevent CONST_Makefile from searching the "tomcat" directory.