### PR TITLE
Prevent property renaming in print directive

### DIFF
--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -401,7 +401,7 @@ app.PrintController.prototype.cancel = function() {
  * @export
  */
 app.PrintController.prototype.changeLayout = function(newLayout) {
-  this.layout = newLayout;
+  this['layout'] = newLayout;
   this.useOptimalScale_();
   this.map_.render();
 };
@@ -412,7 +412,7 @@ app.PrintController.prototype.changeLayout = function(newLayout) {
  * @export
  */
 app.PrintController.prototype.changeScale = function(newScale) {
-  this.scale = newScale;
+  this['scale'] = newScale;
   this.map_.render();
 };
 


### PR DESCRIPTION
The `layout` and `scale` properties of `app.PrintController` are defined using the bracket notation. For example, this is how the `layout` property is defined in the constructor:

```js
/**
 * @type {string}
 */
this['layout'] = this['layouts'][0];
```

So when accessing these properties the bracket notation must be used as well. Do not ever mix the bracket and dot notations for a given property.