### PR TITLE
Use htmlmin in templatecache.mako.js

### DIFF
--- a/CONST_Makefile
+++ b/CONST_Makefile
@@ -515,7 +515,7 @@ $(OUTPUT_DIR)/build.css: $(LESS_FILES) .build/node_modules.timestamp
 		.build/node_modules.timestamp
 	./node_modules/openlayers/node_modules/.bin/closure-util build $< $@
 
-$(OUTPUT_DIR)/templatecache.js: templatecache.mako.js $(APP_PARTIALS_FILES)
+$(OUTPUT_DIR)/templatecache.js: templatecache.mako.js $(APP_PARTIALS_FILES) .build/dev-requirements.timestamp
 	mkdir -p $(dir $@)
 	PYTHONIOENCODING=UTF-8 $(VENV_BIN)/mako-render --var "partials=$(APP_PARTIALS_FILES)" $< > $@
 

--- a/CONST_dev-requirements.txt
+++ b/CONST_dev-requirements.txt
@@ -5,3 +5,4 @@ c2c.template>=1.2.dev
 c2c.versions==1.0.0
 https://github.com/Pylons/pyramid/archive/1e02bbfc0df09259bf207112acf019c8dba44a90.zip#egg=pyramid>=1.6.dev
 pyramid_debugtoolbar
+htmlmin==0.1.10

--- a/templatecache.mako.js
+++ b/templatecache.mako.js
@@ -8,13 +8,12 @@
 <%
   import re
   import os
+  import htmlmin
   _partials = {}
   for partial in partials.split(' '):
       f = file(partial)
       content = unicode(f.read().decode('utf8'))
-      content = re.sub(r'>\s*<' , '><', content)
-      content = re.sub(r'\s\s+', ' ', content)
-      content = re.sub(r'\n', '', content)
+      content = htmlmin.minify(content, remove_comments=True)
       content = re.sub(r"'", "\\'", content)
       dirname, filename = os.path.split(partial)
       subdirname = os.path.basename(dirname.rstrip(os.sep))


### PR DESCRIPTION
This PR changes `templatecache.mako.js` to use the `htmlmin` package rather than minifying the HTML code ourselves.

The original problem was found by @pgiraud, where our code just blindly removed newline characters.

And

```html
<button>test</button>
<button>test</button>
```

is not the same as

```html
<button>test</button><button>test</button>
```

@pgiraud, could you please test this?