### PR TITLE
Remove config vars to avoid errors with c2c-template

### DIFF
--- a/CONST_vars.yaml
+++ b/CONST_vars.yaml
@@ -71,6 +71,9 @@ vars:
     closure_library_path: 'process.stdout.write(require("openlayers/node_modules/closure-util").getLibraryPath())'
     node_modules_path: "{directory}/node_modules"
 
+    layers: {}
+    reset_password: {}
+
     # pyramid_closure configuration
     # Each item in the roots_with_prefix array is an array with two elements. The
     # first element is the path pyramid_closure passed to request.static_url. The


### PR DESCRIPTION
With a recent version of c2c-template being more strict on variables, the build doesn't pass.

The two missing config variables are "layers" and "reset_password".
I don't know if removing them from `CONFIG_VARS` in `CONST_Makefile` is a good idea, though.
@sbrunner can you please confirm?

Note: this is a blocker bug for now.