### PR TITLE
Adding feature count to mymaps icon

### DIFF
--- a/geoportailv3/static/js/draw/drawdirective.js
+++ b/geoportailv3/static/js/draw/drawdirective.js
@@ -45,7 +45,8 @@ app.drawDirective = function(appDrawTemplateUrl) {
     scope: {
       'map': '=appDrawMap',
       'active': '=appDrawActive',
-      'queryActive': '=appDrawQueryactive'
+      'queryActive': '=appDrawQueryactive',
+      'featureCount': '=appDrawFeaturecount'
     },
     controller: 'AppDrawController',
     controllerAs: 'ctrl',
@@ -88,6 +89,12 @@ app.DrawController = function($scope, ngeoDecorateInteraction,
    * @export
    */
   this.active;
+
+  /**
+   * @type {number}
+   * @export
+   */
+  this.featureCount;
 
   /**
    * @type {number}
@@ -231,6 +238,11 @@ app.DrawController = function($scope, ngeoDecorateInteraction,
   goog.events.listen(drawCircle, ol.interaction.DrawEventType.DRAWEND,
       this.onDrawEnd_, false, this);
 
+  $scope.$watch(goog.bind(function() {
+    return this.drawnFeatures_.getCollection().getArray().length;
+  }, this), goog.bind(function(newVal) {
+    this.featureCount = newVal;
+  }, this));
 
   // Watch the "active" property, and disable the draw interactions
   // when "active" gets set to false.

--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -158,6 +158,11 @@ app.MainController = function(
   this['mymapsOpen'] = false;
 
   /**
+   * @type {number}
+   */
+  this['drawnFeatureCount'] = -1;
+
+  /**
    * @type {boolean}
    */
   this['printOpen'] = false;

--- a/geoportailv3/static/js/mymapsservice.js
+++ b/geoportailv3/static/js/mymapsservice.js
@@ -230,7 +230,14 @@ app.Mymaps.prototype.getMapId = function() {
 app.Mymaps.prototype.setCurrentMapId = function(mapId, collection) {
   this.setMapId(mapId);
 
+  var msg = this.gettext_('Carte Mymaps en chargement');
+  /**
+   * @type {angular.JQLite}
+   * @private
+   */
+  this.notificationLoading_ = this.notify_(msg);
   this.loadMapInformation();
+
   this.loadFeatures_().then(goog.bind(function(features) {
     var encOpt = /** @type {olx.format.ReadOptions} */ ({
       dataProjection: 'EPSG:2169',
@@ -244,6 +251,7 @@ app.Mymaps.prototype.setCurrentMapId = function(mapId, collection) {
       feature.setStyle(this.featureStyleFunction_);
     }, this);
 
+    this.notificationLoading_.alert('close');
     collection.extend(
         /** @type {!Array<(null|ol.Feature)>} */ (jsonFeatures));
   }, this));

--- a/geoportailv3/static/js/notifyservice.js
+++ b/geoportailv3/static/js/notifyservice.js
@@ -24,6 +24,7 @@ app.notifyFactory = function() {
 
   /**
    * @param {string} msg Message to show.
+   * @return {angular.JQLite}
    */
   function notify(msg) {
     var el = angular.element('<div class="alert alert-warning fade"></div>');
@@ -33,6 +34,7 @@ app.notifyFactory = function() {
     window.setTimeout(function() {
       el.alert('close');
     }, 7000);
+    return el;
   }
 };
 

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -189,7 +189,7 @@
           <a href translate>Couches</a>
         </li>
         <li ngeo-btn ng-model="mainCtrl.mymapsOpen" class="mymaps icon">
-          <a href translate>My Maps</a>
+        <a href translate>Mymaps <span ng-show="mainCtrl.drawnFeatureCount > 0">({{ mainCtrl.drawnFeatureCount }})</span></a>
         </li>
         <li ngeo-btn ng-model="mainCtrl.infosOpen" class="infos icon">
           <a href translate>Infos</a>
@@ -207,7 +207,8 @@
         <a href translate ngeo-btn ng-model="mainCtrl.drawOpen">Dessin</a>
           <app-draw app-draw-map="::mainCtrl.map"
             app-draw-active="mainCtrl.drawOpen"
-            app-draw-queryactive="mainCtrl.queryActive">
+            app-draw-queryactive="mainCtrl.queryActive"
+            app-draw-featurecount="mainCtrl.drawnFeatureCount">
           </app-draw>
         </li>
         <li class="hidden-xs measure icon" ng-class="mainCtrl.measureOpen ? 'active' : ''">


### PR DESCRIPTION
fix #897 #896 

This shows a drawn feature count in the Mymaps Icon . It counts drawn Features, regardless if its contained in a Mymap or simply drawn by user.  
Is this obvious enough to satisfy request in #897 ? @jaykayone 

@pgiraud Can we somehow make it more obvious like a badge with the count on top of the icon ? my css foo is not very strong  ....  