### PR TITLE
Use fid property name instead of id property name

### DIFF
--- a/geoportailv3/mymaps.py
+++ b/geoportailv3/mymaps.py
@@ -223,7 +223,7 @@ class Feature(Base):
                           showOrientation=self.show_orientation,
                           linestyle='plain' if self.linestyle == 0
                           else 'dashed' if self.linestyle == 1 else 'dotted',
-                          id=self.id,
+                          fid=self.id,
                           symbolId=self.symbol_id,
                           angle=self.angle if self.angle is not None else 0,
                           size=self.size if self.size is not None else 10,

--- a/geoportailv3/static/js/draw/drawnfeaturesservice.js
+++ b/geoportailv3/static/js/draw/drawnfeaturesservice.js
@@ -250,7 +250,7 @@ app.DrawnFeatures.prototype.saveFeatureInMymaps_ = function(feature) {
     this.appMymaps_.saveFeature(feature)
       .then(goog.bind(function(resp) {
           var featureId = resp['id'];
-          currentFeature.set('id', featureId);
+          currentFeature.set('fid', featureId);
           feature.set('__saving__', false);
         }, this));
   }

--- a/geoportailv3/static/js/mymapsservice.js
+++ b/geoportailv3/static/js/mymapsservice.js
@@ -642,7 +642,7 @@ app.Mymaps.prototype.getMapInformation = function() {
  */
 app.Mymaps.prototype.deleteFeature = function(feature) {
   return this.$http_.delete(this.mymapsDeleteFeatureUrl_ +
-      feature.get('id')).then(goog.bind(
+      feature.get('fid')).then(goog.bind(
       /**
        * @param {angular.$http.Response} resp Ajax response.
        * @return {app.MapsResponse} The "mymaps" web service response.

--- a/geoportailv3/views/mymaps.py
+++ b/geoportailv3/views/mymaps.py
@@ -222,7 +222,7 @@ class Mymaps(object):
                 replace(u'\ufffd', '?')
             feature = geojson.loads(feature,
                                     object_hook=geojson.GeoJSON.to_instance)
-            feature_id = feature.properties.get('id')
+            feature_id = feature.properties.get('fid')
 
             if feature_id:
                 cur_feature = DBSession.query(Feature).get(feature_id)
@@ -258,7 +258,7 @@ class Mymaps(object):
                 loads(features, object_hook=geojson.GeoJSON.to_instance)
 
             for feature in feature_collection['features']:
-                feature_id = feature.properties.get('id')
+                feature_id = feature.properties.get('fid')
 
                 if feature_id:
                     cur_feature = DBSession.query(Feature).get(feature_id)


### PR DESCRIPTION
Fixes #1110 
It seems that the name "id" as a feature property name is reserved by mapfish-print.
When some features have the same id value, it causes the "feature" to not be printed.

Then to bypass the problem we use "fid" instead of "id".
