### PR TITLE
Only layers having a source (not the blank layer)

### DIFF
--- a/geoportailv3/static/js/query/querydirective.js
+++ b/geoportailv3/static/js/query/querydirective.js
@@ -351,6 +351,11 @@ app.QueryController = function($sce, $timeout, $scope, $http,
               }
             }
             return false;
+          }, this, function(layer) {
+            if (!layer.getSource()) {
+              return false;
+            }
+            return true;
           });
           this.map_.getViewport().style.cursor = hit ? 'pointer' : '';
         }


### PR DESCRIPTION
forEachLayerAtPixel was not working with the blank layer.