### PR TITLE
Set Piwik Site ID to theme

### DIFF
--- a/geoportailv3/static/js/themeservice.js
+++ b/geoportailv3/static/js/themeservice.js
@@ -7,16 +7,42 @@ goog.require('app.Themes');
 goog.require('ngeo.Location');
 
 
+/**
+ * @typedef {{push: function(Array<string>)}}
+ */
+app.Piwik;
+
+
 
 /**
  * @constructor
+ * @param {angular.$window} $window Global Scope.
  * @param {ngeo.Location} ngeoLocation ngeo Location service.
  * @param {app.Themes} appThemes
  * @param {app.ScalesService} appScalesService Service returning scales.
  * @param {Array.<number>} maxExtent Constraining extent.
  * @ngInject
  */
-app.Theme = function(ngeoLocation, appThemes, appScalesService, maxExtent) {
+app.Theme = function($window, ngeoLocation, appThemes,
+    appScalesService, maxExtent) {
+
+  /**
+   * @const
+   * @private
+   * @type {Object}
+   */
+  this.piwikSiteIdLookup_ = {
+    'main': 18,
+    'tourisme': 7,
+    'emwelt': 8,
+    'eau': 6
+  };
+
+  /**
+   * @type {angular.$window}
+   * @private
+   */
+  this.window_ = $window;
 
   /**
    * @type {app.ScalesService}
@@ -57,6 +83,15 @@ app.Theme = function(ngeoLocation, appThemes, appScalesService, maxExtent) {
  */
 app.Theme.prototype.setCurrentTheme = function(themeId, map) {
   this.currentTheme_ = themeId;
+
+  var piwikSiteId = this.piwikSiteIdLookup_[this.currentTheme_];
+  if (!goog.isDefAndNotNull(piwikSiteId)) {
+    piwikSiteId = this.piwikSiteIdLookup_[app.Theme.DEFAULT_THEME_];
+  }
+  var piwik = /** @type {app.Piwik} */ (this.window_['_paq']);
+  piwik.push(['setSiteId', piwikSiteId]);
+  piwik.push(['trackPageView']);
+
   this.setLocationPath_(this.currentTheme_);
   this.appThemes_.getThemeObject(this.currentTheme_).then(goog.bind(
       /**

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -295,12 +295,12 @@
     <!-- Piwik -->
       <script type="text/javascript">
         var _paq = _paq || [];
-        _paq.push(['trackPageView']);
+        // We do the page track in themeservice to capture any theme changes
+        //_paq.push(['trackPageView']); 
         _paq.push(['enableLinkTracking']);
         (function() {
           var u="//statistics.geoportail.lu/";
           _paq.push(['setTrackerUrl', u+'piwik.php']);
-          _paq.push(['setSiteId', 18]);
           var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
           g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
         })();


### PR DESCRIPTION
Record a visit using the right Piwik Site ID. This will also record a separate visit if user changes the Theme.