### PR TITLE
Add build-api to build target dependencies

### DIFF
--- a/geoportailv3.mk
+++ b/geoportailv3.mk
@@ -101,6 +101,9 @@ build-api: \
 	build-js-api \
 	build-css-api
 
+# Add new dependency to build target
+build: build-api
+
 .PHONY: build-js-api
 build-js-api: \
 	$(API_OUTPUT_DIR)/apiv3.js


### PR DESCRIPTION
Makes sure that travis builds the api as well