### PR TITLE
Position of marker can is LUREF by default

### DIFF
--- a/jsapi/examples/marker.js
+++ b/jsapi/examples/marker.js
@@ -2,16 +2,14 @@ goog.provide('marker');
 
 goog.require('lux');
 
-var position =  [ 682773.755, 6394645.349 ];
 var map = new lux.Map({
   target: 'mapContainer',
-  position: position,
-  zoom: 14,
-  layers: [ 'streets_jpeg' ]
+  zoom: 14
 });
 
+var markerPos = [ 91904, 61566 ];
 map.showMarker({
-  position: position,
+  position: markerPos,
   autoCenter: true,
   positioning: 'center-center',
   iconURL: 'http://apps.geoportail.lu/exemple_api/exemplesWikiGeoAPI/lion.png',

--- a/jsapi/externs/luxx.js
+++ b/jsapi/externs/luxx.js
@@ -86,6 +86,14 @@ luxx.MarkerOptions.prototype.position;
 
 
 /**
+ * The projection of the position coordinates.
+ * Default is `2169`.
+ * @type {string|number}
+ */
+luxx.MarkerOptions.prototype.positionSrs;
+
+
+/**
  * Tells whether the map should be recentered to the marker position.
  * @type {boolean|undefined}
  */

--- a/jsapi/src/main.js
+++ b/jsapi/src/main.js
@@ -239,7 +239,19 @@ lux.Map.prototype.showMarker = function(options) {
   image.src = options.iconURL ||
       'http://openlayers.org/en/master/examples/data/icon.png';
   element.appendChild(image);
-  var position = options.position || this.getView().getCenter();
+
+  var position;
+  if (options.position) {
+    position = ol.proj.transform(
+        options.position,
+        (options.positionSrs) ?
+            'EPSG:' + options.positionSrs.toString() : 'EPSG:2169',
+        'EPSG:3857'
+    );
+  } else {
+    position = this.getView().getCenter();
+  }
+
   this.addOverlay(new ol.Overlay({
     element: element,
     position: position,


### PR DESCRIPTION
With this pull request the position of the marker is now correctly taken into account. Also, it's possible to specify the coordinates system with `positionSrs`.

@tonio please review.