### PR TITLE
Less intrusive CSS for controls

### DIFF
--- a/geoportailv3/static/less/geoportailv3.api.less
+++ b/geoportailv3/static/less/geoportailv3.api.less
@@ -115,6 +115,14 @@
     padding: @padding;
     width: 100%;
   }
+
+  .lux-search {
+    position: absolute;
+    top: .45em;
+    left: 50%;
+    margin-left: -7em;
+    z-index: 10;
+  }
 }
 
 

--- a/geoportailv3/static/less/geoportailv3.api.less
+++ b/geoportailv3/static/less/geoportailv3.api.less
@@ -34,8 +34,9 @@
     bottom: .2em;
     right: 0;
   }
-  .ol-mouse-position {
+  .lux-mouse-position {
     background-color: @bg;
+    position: absolute;
     top: auto;
     bottom: 0;
     height: @mouseposition-height;

--- a/geoportailv3/static/less/geoportailv3.api.less
+++ b/geoportailv3/static/less/geoportailv3.api.less
@@ -81,42 +81,41 @@
       border-radius: 0 0 @border-radius @border-radius;
     }
   }
-}
-
-.lux-dropdown {
-  background-color: @bg;
-  border-radius: @border-radius;
-  border: @border;
-  display: inline-block;
-  position: relative;
-  width: 10em;
-  position: absolute;
-  bottom: .5em;
-  left: .5em;
-  z-index: 3;
-  &::after {
-    font-family: @font;
-    font-weight: bold;
-    color: @color;
-    content: 'v';
+  .lux-bg-selector {
+    background-color: @bg;
+    border-radius: @border-radius;
+    border: @border;
+    display: inline-block;
+    width: 10em;
     position: absolute;
-    right: .6em;
-    top: .75em;
-    pointer-events: none;
+    bottom: .5em;
+    left: .5em;
+    z-index: 3;
+    &::after {
+      font-family: @font;
+      font-weight: bold;
+      color: @color;
+      content: 'v';
+      position: absolute;
+      right: .6em;
+      top: .75em;
+      pointer-events: none;
+    }
+  }
+  .lux-bg-selector-select {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background: @bg;
+    border: 0;
+    color: @color;
+    font-family: @font;
+    font-size: 19px;
+    padding: @padding;
+    width: 100%;
   }
 }
-.lux-dropdown-select {
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-  background: @bg;
-  border: 0;
-  color: @color;
-  font-family: @font;
-  font-size: 19px;
-  padding: @padding;
-  width: 100%;
-}
+
 
 .lux-search {
   position: relative;

--- a/jsapi/examples/search.html
+++ b/jsapi/examples/search.html
@@ -13,13 +13,6 @@
         height   : 400px;
         position : relative;
       }
-      .lux-search {
-        position    : absolute;
-        top         : .45em;
-        left        : 50%;
-        margin-left : -7em;
-        z-index     : 10;
-      }
     </style>
   </head>
   <body>

--- a/jsapi/examples/simple.html
+++ b/jsapi/examples/simple.html
@@ -13,13 +13,6 @@
         width: 100%;
         height: 400px;
       }
-      .lux-bgselector {
-        width: 10em;
-        position: absolute;
-        bottom: .5em;
-        left: .5em;
-        z-index: 3;
-      }
     </style>
   </head>
   <body>

--- a/jsapi/examples/simple.html
+++ b/jsapi/examples/simple.html
@@ -13,6 +13,13 @@
         width: 100%;
         height: 400px;
       }
+      .lux-bgselector {
+        width: 10em;
+        position: absolute;
+        bottom: .5em;
+        left: .5em;
+        z-index: 3;
+      }
     </style>
   </head>
   <body>

--- a/jsapi/src/main.js
+++ b/jsapi/src/main.js
@@ -463,9 +463,9 @@ lux.Map.prototype.addBgSelector = function(target) {
       return;
     }
     var container = document.createElement('div');
-    container.classList.add('lux-dropdown');
+    container.classList.add('lux-bg-selector');
     var select = document.createElement('select');
-    select.classList.add('lux-dropdown-select');
+    select.classList.add('lux-bg-selector-select');
 
     var conf = this.layersConfig;
     var backgrounds = Object.keys(conf).filter(function(l) {

--- a/jsapi/src/main.js
+++ b/jsapi/src/main.js
@@ -183,6 +183,7 @@ lux.Map = function(options) {
     if (el instanceof Element) {
       controls.push(new ol.control.MousePosition({
         target: el,
+        className: 'lux-mouse-position',
         projection: ol.proj.get(srs),
         coordinateFormat: function(coord) {
           var decimal = 1;


### PR DESCRIPTION
Make it so styling for mouse position or background selector controls is applied only when added to the map.