### PR TITLE
Factorize and enhance sanitizeFilename method

### DIFF
--- a/geoportailv3/static/js/appmodule.js
+++ b/geoportailv3/static/js/appmodule.js
@@ -26,3 +26,12 @@ app.module = angular.module('app', [ngeo.module.name, 'gettext'])
 // and avoid problems when using both ngeoLocation and ng-include in
 // the application.
 app.module.config(ngeo.mockLocationProvider);
+
+/**
+ * @param {string} name The string to sanitize.
+ * @return {string} The sanitized string.
+ */
+app.sanitizeFilename = function(name) {
+  name = name.replace(/\s+/g, '_'); // Replace white space with _.
+  return name.replace(/[^a-z0-9\-\_]/gi, ''); // Strip any special character.
+};

--- a/geoportailv3/static/js/draw/featurepopupdirective.js
+++ b/geoportailv3/static/js/draw/featurepopupdirective.js
@@ -267,7 +267,7 @@ app.FeaturePopupController.prototype.exportKml = function() {
     featureProjection: this['map'].getView().getProjection()
   });
   this.exportFeatures_(kml, 'kml',
-      this.sanitizeFilename_(/** @type {string} */(this.feature.get('name'))));
+      app.sanitizeFilename(/** @type {string} */(this.feature.get('name'))));
   this.appFeaturePopup_.toggleDropdown();
 };
 
@@ -282,17 +282,6 @@ app.FeaturePopupController.prototype.exportGpx = function(isTrack) {
       /** @type {string} */(this.feature.get('name')), isTrack);
 
   this.appFeaturePopup_.toggleDropdown();
-};
-
-
-/**
- * @param {string} name The string to sanitize.
- * @return {string} The sanitized string.
- * @private
- */
-app.FeaturePopupController.prototype.sanitizeFilename_ = function(name) {
-  name = name.replace(/\s+/gi, '_'); // Replace white space with _.
-  return name.replace(/[^a-zA-Z0-9\-]/gi, ''); // Strip any special charactere.
 };
 
 

--- a/geoportailv3/static/js/exportservice.js
+++ b/geoportailv3/static/js/exportservice.js
@@ -108,7 +108,7 @@ app.Export.prototype.exportGpx = function(features, name, isTrack) {
       ' version="1.1" ' +
       'xsi:schemaLocation="http://www.topografix.com/GPX/1/1 ' +
       'http://www.topografix.com/GPX/1/1/gpx.xsd" creator="geoportail.lu" ');
-  this.exportFeatures_(gpx, 'gpx', this.sanitizeFilename_(name));
+  this.exportFeatures_(gpx, 'gpx', app.sanitizeFilename(name));
 };
 
 
@@ -259,7 +259,7 @@ app.Export.prototype.exportKml = function(feature, name) {
       dataProjection: 'EPSG:4326',
       featureProjection: this['map'].getView().getProjection()
     });
-  this.exportFeatures_(kml, 'kml', this.sanitizeFilename_(name));
+  this.exportFeatures_(kml, 'kml', app.sanitizeFilename(name));
 };
 
 
@@ -295,16 +295,5 @@ app.Export.prototype.exportFeatures_ =
       form[0].submit();
       form.remove();
     };
-
-
-/**
- * @param {string} name The string to sanitize.
- * @return {string} The sanitized string.
- * @private
- */
-app.Export.prototype.sanitizeFilename_ = function(name) {
-  name = name.replace(/\s+/gi, '_'); // Replace white space with _.
-  return name.replace(/[^a-zA-Z0-9\-]/gi, ''); // Strip any special charactere.
-};
 
 app.module.service('appExport', app.Export);

--- a/geoportailv3/static/js/mymaps/mymapsdirective.js
+++ b/geoportailv3/static/js/mymaps/mymapsdirective.js
@@ -439,17 +439,6 @@ app.MymapsDirectiveController.prototype.exportGpx = function(isTrack) {
 
 
 /**
- * @param {string} name The string to sanitize.
- * @return {string} The sanitized string.
- * @private
- */
-app.MymapsDirectiveController.prototype.sanitizeFilename_ = function(name) {
-  name = name.replace(/\s+/gi, '_'); // Replace white space with _.
-  return name.replace(/[^a-zA-Z0-9\-]/gi, ''); // Strip any special charactere.
-};
-
-
-/**
  * Import a GPX file.
  * @export
  */
@@ -517,7 +506,7 @@ app.MymapsDirectiveController.prototype.exportKml = function() {
     featureProjection: this['map'].getView().getProjection()
   });
   this.exportFeatures_(kml, 'kml',
-      this.sanitizeFilename_(this.appMymaps_.mapTitle));
+      app.sanitizeFilename(this.appMymaps_.mapTitle));
 };
 
 


### PR DESCRIPTION
With this pull request the sanitizeFilename is declared only once.
Also the regexp has been improved.

```js
name.replace(/\s+/gi, '_')
name.replace(/[^a-zA-Z0-9\-]/gi, '')
```
is changed to
```js
name.replace(/\s+/g, '_')
name.replace(/[^a-z0-9\-\_]/gi, '')
```

First regexp doesn't need to be case insensitive.
Underscores are not removed any more in the second one.
Also, because the second one is case insensitive, we don't need to search for "A-Z", "a-z" is already removing upper cased characters.

Please review.