### PR TITLE
Make showMarker & showFeatures coherent.

### DIFF
--- a/jsapi/examples/marker.js
+++ b/jsapi/examples/marker.js
@@ -5,7 +5,8 @@ goog.require('lux');
 
 var map = new lux.Map({
   target: 'mapContainer',
-  zoom: 14
+  zoom: 14,
+  bgLayer: 'topo_bw_jpeg'
 });
 
 var markerPos = [ 91904, 61566 ];

--- a/jsapi/externs/luxx.js
+++ b/jsapi/externs/luxx.js
@@ -138,11 +138,17 @@ luxx.MarkerOptions.prototype.html;
 
 
 /**
- * If set, the popup is displayed when hovering the marker and is closed on
- * mouseout.
+ * If set, the popup is displayed when clicking the marker.
  * @type {boolean|undefined}
  */
-luxx.MarkerOptions.prototype.hover;
+luxx.MarkerOptions.prototype.click;
+
+/**
+ * The container for the marker popup, either the element itself or
+ * the `id` of the element.
+ * @type {Element|string}
+ */
+luxx.MarkerOptions.prototype.target;
 
 /**
  * Object literal with config options for the layer.
@@ -280,6 +286,19 @@ luxx.FeaturesOptions.prototype.ids;
  * @type {string|number}
  */
 luxx.FeaturesOptions.prototype.layer;
+
+/**
+ * The container for the feature popup, either the element itself or
+ * the `id` of the element.
+ * @type {Element|string}
+ */
+luxx.FeaturesOptions.prototype.target;
+
+/**
+ * If set, the popup is displayed when clicking the feature.
+ * @type {boolean|undefined}
+ */
+luxx.FeaturesOptions.prototype.click;
 
 /**
  * Object literal with config options for the vector (GPX/KML) layer.


### PR DESCRIPTION
- Use `click: true` options in `features` and `showMarker` to switch from hover to click mode.
- Use `target` on both to render popup content in external dom element.

Fix #1526
