### PR TITLE
Minor css fixes to poi-feature form

### DIFF
--- a/geoportailv3/static/less/featurepopup.less
+++ b/geoportailv3/static/less/featurepopup.less
@@ -152,6 +152,9 @@
     display: none;
   }
 }
+.feature-popup-body textarea {
+  resize: vertical;
+}
 #sidebar .feature-popup-profile {
   .profile {
     border: none;
@@ -167,7 +170,7 @@
 }
 
 .feature-popup-footer {
-  margin: 10px 0 0 0;
+  margin-bottom: 5px;
 }
 
 .feature-popup-heading {


### PR DESCRIPTION
This is a minor css enhancement to the poi-feature form:
 - better padding above the footer buttons
 - only allow vertical resize to the textarea

before:
![draw_form](https://cloud.githubusercontent.com/assets/100959/24400430/b4d596c8-13b0-11e7-98c9-53bc28918aed.png)


after:
![draw_form_after](https://cloud.githubusercontent.com/assets/100959/24400559/18f07e0c-13b1-11e7-9760-beb56dda9033.png)

 