### PR TITLE
Fix layer manager drag element styling

### DIFF
--- a/geoportailv3/static/js/layermanager/layermanager.html
+++ b/geoportailv3/static/js/layermanager/layermanager.html
@@ -7,11 +7,11 @@
     {{layer.get('label') | translate}}
     </div>
     <a class="delete" ng-click="ctrl.removeLayer(layer);"><span class="fa fa-trash-o"></span></a>
-    <a data-toggle="collapse" data-parent="#layermanager-{{::ctrl.uid}}" href="#layermanager-item-{{$index}}">
+    <a class="options-button" data-toggle="collapse" data-parent="#layermanager-{{::ctrl.uid}}" href="#layermanager-item-{{$index}}">
       <span class="collapsed fa fa-ellipsis-h"></span>
       <span class="expanded fa fa-remove"></span>
     </a>
-    <div id="layermanager-item-{{$index}}" class="collapse">
+    <div class="collapse options-body" id="layermanager-item-{{$index}}">
       <a href ng-click="ctrl.changeVisibility(layer)"><span class="fa" ng-class="(layer.opacity > 0) ? 'fa-eye': 'fa-eye-slash'" ></span></a>
       <input class="opacity" type="range" min="0" max="1" step="0.25" ng-model="layer.opacity" />
     </div>

--- a/geoportailv3/static/less/icons.less
+++ b/geoportailv3/static/less/icons.less
@@ -110,11 +110,9 @@ button.icon.search:after,
   content: '\e600';
 }
 
-#catalog,
-#mylayers {
+app-layerinfo {
+  margin: 0 5px;
   .fa-info {
-    margin-left: 5px;
-    margin-right: 5px;
     cursor: pointer;
   }
 }

--- a/geoportailv3/static/less/layermanager.less
+++ b/geoportailv3/static/less/layermanager.less
@@ -25,8 +25,7 @@ li.layermanager-panel {
     margin-left: 5px;
   }
 
-  a[data-toggle=collapse] .expanded,
-  a[data-toggle=collapse] .collapsed {
+  .options-button {
     float: right;
     line-height: inherit;
   }
@@ -56,13 +55,15 @@ li.layermanager-panel {
 }
 
 .sortable-dragger {
-  padding: 2px 10px;
   white-space: nowrap;
   .box-shadow(0px 2px 6px -1px rgba(0, 0, 0, 0.5));
-  .fa {
+
+  app-layerinfo {
     visibility: hidden;
-    &.sortable-handle {
-      visibility: visible;
-    }
   }
+
+  .delete, .options-button, .options-body {
+    display: none;
+  }
+
 }


### PR DESCRIPTION
 - fix dragged element height on firefox
 - hide the options menu when dragging
 - remove the text slide

fixes #1036 

tested on chrome, firefox and IE11