### PR TITLE
Same alignment both in the print and on the screen

### DIFF
--- a/geoportailv3/static/js/mymapsservice.js
+++ b/geoportailv3/static/js/mymapsservice.js
@@ -1377,7 +1377,7 @@ app.Mymaps.prototype.createStyleFunction = function(curMap) {
       return [new ol.style.Style({
         text: new ol.style.Text(/** @type {olx.style.TextOptions} */ ({
           text: this.get('name'),
-          textAlign: 'start',
+          textAlign: 'left',
           font: 'normal ' + featureSize + 'px Sans-serif',
           rotation: this.get('angle'),
           fill: new ol.style.Fill({

--- a/geoportailv3/static/js/print/printdirective.js
+++ b/geoportailv3/static/js/print/printdirective.js
@@ -665,6 +665,9 @@ app.PrintController.prototype.print = function(format) {
                 for (var j = 0; j < style.symbolizers.length; j++) {
                   var symbolizer = style.symbolizers[j];
                   symbolizer['conflictResolution'] = false;
+                  if (symbolizer.labelAlign) {
+                    symbolizer.labelAlign = 'lm';
+                  }
                   if (symbolizer.externalGraphic) {
                     symbolizer.graphicFormat = 'image/png';
                     if (symbolizer.externalGraphic.indexOf('scale=') > 0) {


### PR DESCRIPTION
In ngeo print service when a text rotation is provided, then text alignment is set to center.  Text aligment in Geoportail is left. https://github.com/camptocamp/ngeo/blob/master/src/services/print.js#L755 