### PR TITLE
Disable 3D by default

### DIFF
--- a/geoportailv3/static/js/maincontroller.js
+++ b/geoportailv3/static/js/maincontroller.js
@@ -308,7 +308,13 @@ app.MainController = function(
   this.map_ = this.createMap_();
 
   /**
-   * @const {!olcs.contrib.Manager}
+   * @export
+   * @type {boolean}
+   */
+  this.allow3d = this.ngeoLocation_.hasParam('3d');
+
+  /**
+   * @const {?olcs.contrib.Manager}
    * @private
    */
   this.ol3dm_ = this.createCesiumManager_(cesiumURL);
@@ -474,9 +480,12 @@ app.MainController.Lux3DManager = class extends olcs.contrib.Manager {
 /**
  * @private
  * @param {string} cesiumURL The Cesium URL
- * @return {!olcs.contrib.Manager} The created manager.
+ * @return {olcs.contrib.Manager} The created manager.
  */
 app.MainController.prototype.createCesiumManager_ = function(cesiumURL) {
+  if (!this.allow3d) {
+    return null;
+  }
   // [minx, miny, maxx, maxy]
   var luxembourgRectangle = [5.31, 49.38, 6.64, 50.21].map(ol.math.toRadians);
   goog.asserts.assert(this.map_);
@@ -509,7 +518,7 @@ app.MainController.prototype.toggle3d = function() {
  * @return {boolean} Whether 3D is active.
  */
 app.MainController.prototype.is3dEnabled = function() {
-  return this.ol3dm_.is3dEnabled();
+  return this.allow3d && this.ol3dm_.is3dEnabled();
 };
 
 

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -217,7 +217,7 @@
         </li>
       </ul>
       <ul class="footer-navigation nav navbar-nav pull-right hidden-xs">
-        <li><a href ng-click="mainCtrl.toggle3d()">3d</a></li>
+        <li ng-if="::mainCtrl.allow3d"><a href ng-click="mainCtrl.toggle3d()">3d</a></li>
         <li><a href ng-click="mainCtrl.openFeedback()" translate>Feedback</a></li>
         <li><a ng-href="https://www.geoportail.lu/{{mainCtrl.lang}}/propos/" translate>A Propos</a></li>
         <li><a ng-href="https://www.geoportail.lu/{{mainCtrl.lang}}/documentation/" translate>Aide</a></li>


### PR DESCRIPTION
Having 3D disabled by default makes it possible to merge 3D code in master without impact to the production.

The 3D code will be dormant until the project is complete and the features go live.

Being able to merge regularly to master avoid the two branches to diverge and share common work like updating the dependencies and modernizing the code.