### PR TITLE
Display tile coordinates

### DIFF
--- a/geoportailv3/static/js/olcs/lux3dmanager.js
+++ b/geoportailv3/static/js/olcs/lux3dmanager.js
@@ -43,7 +43,7 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
    */
   instantiateOLCesium() {
     goog.asserts.assert(this.map);
-    const terrainExaggeration = parseFloat(this.ngeoLocation_.getParam('terrain_exaggeration') || '2.0');
+    const terrainExaggeration = parseFloat(this.ngeoLocation_.getParam('terrain_exaggeration') || '1.5');
 
     const sceneOptions = /** @type {!Cesium.SceneOptions} */ ({terrainExaggeration});
     const ol3d = new olcs.OLCesium({map: this.map, sceneOptions});

--- a/geoportailv3/static/js/olcs/lux3dmanager.js
+++ b/geoportailv3/static/js/olcs/lux3dmanager.js
@@ -50,6 +50,10 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
 
     const scene = ol3d.getCesiumScene();
 
+    if (this.ngeoLocation_.hasParam('tile_coordinates')) {
+      scene.imageryLayers.addImageryProvider(new Cesium['TileCoordinatesImageryProvider']());
+    }
+
     // for performance, limit terrain levels to be loaded
     const unparsedTerrainLevels = this.ngeoLocation_.getParam('terrain_levels');
     const availableLevels = unparsedTerrainLevels ? unparsedTerrainLevels.split(',').map(e => parseInt(e, 10)) : undefined;

--- a/geoportailv3/static/js/olcs/lux3dmanager.js
+++ b/geoportailv3/static/js/olcs/lux3dmanager.js
@@ -24,10 +24,27 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
      */
     this.ngeoLocation_ = ngeoLocation;
 
+    /*
+     * A factor used to increase the screen space error of terrain tiles when they are partially in fog. The effect is to reduce
+     * the number of terrain tiles requested for rendering. If set to zero, the feature will be disabled. If the value is increased
+     * for mountainous regions, less tiles will need to be requested, but the terrain meshes near the horizon may be a noticeably
+     * lower resolution. If the value is increased in a relatively flat area, there will be little noticeable change on the horizon.
+     * type {Number}
+     * default 2.0
+     */
     if (ngeoLocation.hasParam('fog_sse_factor')) {
       this.fogSSEFactor = parseFloat(ngeoLocation.getParam('fog_sse_factor'));
     }
 
+    /*
+     * A scalar that determines the density of the fog. Terrain that is in full fog are culled.
+     * The density of the fog increases as this number approaches 1.0 and becomes less dense as it approaches zero.
+     * The more dense the fog is, the more aggressively the terrain is culled. For example, if the camera is a height of
+     * 1000.0m above the ellipsoid, increasing the value to 3.0e-3 will cause many tiles close to the viewer be culled.
+     * Decreasing the value will push the fog further from the viewer, but decrease performance as more of the terrain is rendered.
+     * type {Number}
+     * default 2.0e-4
+     */
     if (ngeoLocation.hasParam('fog_density')) {
       this.fogDensity = parseFloat(ngeoLocation.getParam('fog_density'));
     }

--- a/geoportailv3/static/js/olcs/lux3dmanager.js
+++ b/geoportailv3/static/js/olcs/lux3dmanager.js
@@ -30,7 +30,8 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
      * for mountainous regions, less tiles will need to be requested, but the terrain meshes near the horizon may be a noticeably
      * lower resolution. If the value is increased in a relatively flat area, there will be little noticeable change on the horizon.
      * type {Number}
-     * default 2.0
+     * default in Cesium 2.0
+     * default in Ngeo 25.0
      */
     if (ngeoLocation.hasParam('fog_sse_factor')) {
       this.fogSSEFactor = parseFloat(ngeoLocation.getParam('fog_sse_factor'));
@@ -43,7 +44,8 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
      * 1000.0m above the ellipsoid, increasing the value to 3.0e-3 will cause many tiles close to the viewer be culled.
      * Decreasing the value will push the fog further from the viewer, but decrease performance as more of the terrain is rendered.
      * type {Number}
-     * default 2.0e-4
+     * default in Cesium 2.0e-4
+     * default in Ngeo 1.0e-4
      */
     if (ngeoLocation.hasParam('fog_density')) {
       this.fogDensity = parseFloat(ngeoLocation.getParam('fog_density'));


### PR DESCRIPTION
Allow displaying the 3d tiles coordinates for debugging purpose.
Add the tile_coordinates parameter in the URL.
It is possible to adjust quality by  tweaking the following parameters (see commit for details):
- fog_sse_factor;
- fog_density.

Related to https://jira.camptocamp.com/browse/GSLUX-28.