### PR TITLE
Import WMS

### DIFF
--- a/geoportailv3/static/js/wmsservice.js
+++ b/geoportailv3/static/js/wmsservice.js
@@ -114,7 +114,7 @@ app.WmsHelper.prototype.getCapabilities = function(wms) {
         basicWmsUrl = wms;
       }
       this.buildChildLayers_(basicWmsUrl, capabilities['Capability']['Layer'],
-        capabilities['version'], formats, useTiles);
+        capabilities['version'], formats, useTiles, null);
 
       return capabilities;
     }.bind(this), function(e) {
@@ -162,6 +162,7 @@ app.WmsHelper.prototype.getOnlineResource_ = function(capability, service) {
  * @return {Object} Returns the layer object.
  * @param {string} imageFormats The available formats.
  * @param {boolean} useTiles Set if the layer has a max size.
+ * @param {Object} parentLayer Parent layer object in capabilities tree.
  * @private
  */
 app.WmsHelper.prototype.buildChildLayers_ = function(wms, layer, wmsVersion,
@@ -183,8 +184,10 @@ app.WmsHelper.prototype.buildChildLayers_ = function(wms, layer, wmsVersion,
 
   // casacading CRS
   layer.CRS = layer.CRS || [];
-  if(parentLayer) {
-    parentLayer.CRS.forEach(crs => layer.CRS.indexOf(crs) < 0 && layer.CRS.push(crs));
+  if (parentLayer) {
+    parentLayer.CRS.forEach(function(crs) {
+      layer.CRS.indexOf(crs) < 0 && layer.CRS.push(crs);
+    });
   }
 
   if (layer['Layer']) {
@@ -482,8 +485,7 @@ app.WmsHelper.prototype.createWmsLayers = function(map, layer) {
   }
   if (has3857) {
     newLayer.getSource().set('olcs.projection', ol.proj.get('EPSG:3857'));
-  }
-  else if (hasWGS84) {
+  } else if (hasWGS84) {
     newLayer.getSource().set('olcs.projection', ol.proj.get('EPSG:4326'));
   }
   newLayer.set('label', layer['Title']);

--- a/geoportailv3/static/js/wmsservice.js
+++ b/geoportailv3/static/js/wmsservice.js
@@ -436,15 +436,19 @@ app.WmsHelper.prototype.createWmsLayers = function(map, layer) {
       'LAYERS': layer['Name']
     },
     crossOrigin: 'anonymous',
-    ration: 1
+    ratio: 1
   };
 
   var hasLuref = false;
   var has3857 = false;
+  var hasWGS84 = false;
   var projections = layer['CRS'] || layer.SRS || [];
   goog.array.forEach(projections, function(projection) {
     if (projection.toUpperCase() === 'EPSG:2169') {
       hasLuref = true;
+    }
+    if (projection.toUpperCase() === 'EPSG:4326') {
+      hasWGS84 = true;
     }
     if (projection.toUpperCase() === 'EPSG:3857') {
       has3857 = true;
@@ -456,6 +460,8 @@ app.WmsHelper.prototype.createWmsLayers = function(map, layer) {
     imgOptions.params['VERSION'] = '1.1.1';
   } else if (has3857) {
     imgOptions.projection = 'EPSG:3857';
+  } else if (hasWGS84) {
+    imgOptions.projection = 'EPSG:4326';
   } else {
     imgOptions.projection = projections[0];
   }
@@ -473,6 +479,12 @@ app.WmsHelper.prototype.createWmsLayers = function(map, layer) {
       'olcs.extent': app.olcsExtent,
       source: new ol.source.ImageWMS(imgOptions)
     });
+  }
+  if (has3857) {
+    newLayer.getSource().set('olcs.projection', ol.proj.get('EPSG:3857'));
+  }
+  else if (hasWGS84) {
+    newLayer.getSource().set('olcs.projection', ol.proj.get('EPSG:4326'));
   }
   newLayer.set('label', layer['Title']);
   var curMatadata = {'isExternalWms': true,

--- a/geoportailv3/static/js/wmsservice.js
+++ b/geoportailv3/static/js/wmsservice.js
@@ -165,7 +165,7 @@ app.WmsHelper.prototype.getOnlineResource_ = function(capability, service) {
  * @private
  */
 app.WmsHelper.prototype.buildChildLayers_ = function(wms, layer, wmsVersion,
-    imageFormats, useTiles) {
+    imageFormats, useTiles, parentLayer) {
 
   if (!layer['Name']) {
     layer['isInvalid'] = true;
@@ -181,10 +181,16 @@ app.WmsHelper.prototype.buildChildLayers_ = function(wms, layer, wmsVersion,
     layer['useTiles'] = useTiles;
   }
 
+  // casacading CRS
+  layer.CRS = layer.CRS || [];
+  if(parentLayer) {
+    parentLayer.CRS.forEach(crs => layer.CRS.indexOf(crs) < 0 && layer.CRS.push(crs));
+  }
+
   if (layer['Layer']) {
     for (var i = 0; i < layer['Layer'].length; i++) {
       var l = this.buildChildLayers_(wms, layer['Layer'][i], wmsVersion,
-          imageFormats, useTiles);
+          imageFormats, useTiles, layer);
       if (!l) {
         layer['Layer'].splice(i, 1);
         i--;

--- a/geoportailv3/static/js/wmsservice.js
+++ b/geoportailv3/static/js/wmsservice.js
@@ -91,7 +91,7 @@ app.WmsHelper.prototype.getCapabilities = function(wms) {
     separator = '?';
   }
   if (wms.indexOf('Capabilities') === -1) {
-    wms = wms + separator + 'SERVICE=WMS&REQUEST=GetCapabilities';
+    wms = wms + separator + 'SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0';
   }
 
   if (!(wms in this.wmsCapa_)) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "send": "^0.15.0"
   },
   "devDependencies": {
+    "@camptocamp/cesium": "1.40.0",
     "@camptocamp/closure-util": "1.27.0",
     "angular": "1.6.6",
     "angular-animate": "1.6.6",
@@ -42,9 +43,8 @@
     "less-plugin-clean-css": "1.5.1",
     "ngeo": "https://api.github.com/repos/camptocamp/ngeo/tarball/1680664d0",
     "nomnom": "1.8.1",
+    "ol-cesium": "https://api.github.com/repos/openlayers/ol-cesium/tarball/v1.34",
     "openlayers": "https://api.github.com/repos/openlayers/openlayers/tarball/f139b7001a7",
-    "ol-cesium": "https://api.github.com/repos/openlayers/ol-cesium/tarball/ae925e6ca3463",
-    "@camptocamp/cesium": "1.40.0",
     "phantomjs": "~1.9.7-5",
     "phantomjs-prebuilt": "2.1.12",
     "proj4": "2.4.4",


### PR DESCRIPTION
- Link last version of Cesium that has a better support of custom projection.
- Set in lux layers if they support Cesium projection (4326 or 3857) via `olcs.projection` source layer param.
- Call all getCapabilities with VERSION 1.3.0 to get layer available CRS
- Casade CRS definition in getCapabilities