### PR TITLE
Fix 3D WMS

### DIFF
--- a/geoportailv3/static/js/locationinfo/locationinfodirective.js
+++ b/geoportailv3/static/js/locationinfo/locationinfodirective.js
@@ -118,7 +118,7 @@ app.LocationinfoController = function(
   this.featureLayer_ = new ol.layer.Vector({
     source: new ol.source.Vector(),
     zIndex: 1000,
-    altitudeMode: 'clampToGround'
+    'altitudeMode': 'clampToGround'
   });
   this['map'].addLayer(this.featureLayer_);
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "less-plugin-clean-css": "1.5.1",
     "ngeo": "https://api.github.com/repos/camptocamp/ngeo/tarball/1680664d0",
     "nomnom": "1.8.1",
-    "ol-cesium": "https://api.github.com/repos/openlayers/ol-cesium/tarball/v1.34",
+    "ol-cesium": "https://api.github.com/repos/openlayers/ol-cesium/tarball/a3faf8fd766139bd15b96ce684bb366f9ebad87c",
     "openlayers": "https://api.github.com/repos/openlayers/openlayers/tarball/f139b7001a7",
     "phantomjs": "~1.9.7-5",
     "phantomjs-prebuilt": "2.1.12",


### PR DESCRIPTION
The detection of layer projection is not really robust.
Fall back in ol-cesium to use map projection if no layer projection is defined.

Fix WMS layers like "Sentiers autopédestres" in 3D.

Also fix empty layer created on application loading.