### PR TITLE
Add 3D models support

### DIFF
--- a/geoportailv3/static/js/olcs/lux3dmanager.js
+++ b/geoportailv3/static/js/olcs/lux3dmanager.js
@@ -11,8 +11,11 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
    * @param {ol.Map} map The map.
    * @param {ngeo.statemanager.Location} ngeoLocation The location service.
    * @param {angular.Scope} $rootScope The root scope.
+   * @param {Array<string>} tiles3dLayers 3D tiles layers.
+   * @param {string} tiles3dUrl 3D tiles server url.
    */
-  constructor(cesiumUrl, cameraExtentInRadians, map, ngeoLocation, $rootScope) {
+  constructor(cesiumUrl, cameraExtentInRadians, map, ngeoLocation, $rootScope,
+              tiles3dLayers, tiles3dUrl) {
     super(cesiumUrl, $rootScope, {
       map,
       cameraExtentInRadians
@@ -55,6 +58,24 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
      * @const {ol.Extent}
      */
     this.luxCameraExtentInRadians = cameraExtentInRadians;
+
+    /**
+     * Array of 3D tiles set used for buildings/vegetation
+     * @type {Array<Cesium.Cesium3DTileset>}
+     */
+    this.tilesets3d = [];
+
+    /**
+     * @private
+     * @type {Array<string>}
+     */
+    this.tiles3dLayers_ = tiles3dLayers;
+
+    /**
+     * @private
+     * @type {string}
+     */
+    this.tiles3dUrl_ = tiles3dUrl;
   }
 
   /**
@@ -85,6 +106,32 @@ app.olcs.Lux3DManager = class extends ngeo.olcs.Manager {
     }
 
     return ol3d;
+  }
+
+  /***
+   * Initialize 3D tiles layers (buildings/vegetation)
+   * @param {boolean} visible Initial visibility of 3D tiles.
+   */
+  init3dTiles(visible) {
+    const scene = this.ol3d.getCesiumScene();
+    this.tiles3dLayers_.forEach((layer) => {
+      const url = this.tiles3dUrl_ + layer;
+      const tileset = new Cesium.Cesium3DTileset({
+        url: url,
+        maximumNumberOfLoadedTiles: 3,
+        show: visible
+      });
+      this.tilesets3d.push(tileset);
+      scene.primitives.add(tileset);
+    });
+  }
+
+  /**
+   * Change 3D tiles layers visibility
+   * @param {boolean} visible Visibility.
+   */
+  set3dTilesetVisible(visible) {
+    this.tilesets3d.forEach((tileset) => tileset.show = visible);
   }
 
   /**

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -89,6 +89,10 @@
             ✕
           </button>
           <app-backgroundlayer app-backgroundlayer-map="::mainCtrl.map"></app-backgroundlayer>
+          <div class="hidden-2d text-center" ng-click="mainCtrl.toggleTiles3dVisibility()">
+            <i class="fa" ng-class="mainCtrl.tiles3dVisible ? 'fa-check-square' : 'fa-square'"></i>
+            <span translate>Afficher les modèles 3D</span>
+          </div>
           <ul class="nav nav-tabs">
             <li role="presentation">
             <a href="#mylayers" data-toggle="tab">
@@ -383,6 +387,8 @@
          appModule.constant('bboxLidar', [${lidar['minx']},${lidar['miny']} ,${lidar['maxx']} ,${lidar['maxy']}]);
          appModule.constant('bboxSrsLidar', "${lidar['srs']}");
          appModule.constant('lidarDemoUrl', "${lidar['demo_url']}");
+         appModule.constant('tiles3dLayers', ['buildings25d', 'buildings3d', 'bridges3d','vegetation_point_cloud']);
+         appModule.constant('tiles3dUrl', 'http://3dtiles.geoportail.lu/3dtiles/');
 
 % if overview_map_show:
          appModule.constant('appOverviewMapShow', true);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "less-plugin-clean-css": "1.5.1",
     "ngeo": "https://api.github.com/repos/camptocamp/ngeo/tarball/f81ab0c24624cfbc5e6974a27c4c9f0d4d3f1b38",
     "nomnom": "1.8.1",
-    "ol-cesium": "https://api.github.com/repos/openlayers/ol-cesium/tarball/628501a",
+    "ol-cesium": "https://api.github.com/repos/openlayers/ol-cesium/tarball/9bc93a85a2cf25fbec11905597f3c5cbc18acea5",
     "openlayers": "4.6.4",
     "phantomjs": "~1.9.7-5",
     "phantomjs-prebuilt": "2.1.12",


### PR DESCRIPTION
First shot first 3D tiles models integration.
Lux3DManager handle this, from mainController control. I prefer this than doing everything in mainController.

To have buildings aligned to terrain you need both parameters:

- &terrain_exaggeration=1
- &own_terrain

@gberaudo please review the approach.
I'm not sure if add angular constant in index.html is the best thing to do ?

For the ui, we propose to have a combo only in 3D mode under the background layer selector

![image](https://user-images.githubusercontent.com/1491924/36981177-bf14fc02-208c-11e8-9f9b-e93eab7da0e5.png)

Please make comments.