### PR TITLE
Fix CSS for offline message

### DIFF
--- a/geoportailv3/static/less/offline.less
+++ b/geoportailv3/static/less/offline.less
@@ -1,4 +1,3 @@
-
 ngeo-offline {
   div {
     z-index: 1;
@@ -66,4 +65,11 @@ ngeo-offline {
 }
 .offline .offline-msg {
   display: block;
+  position: absolute;
+  z-index: 10000;
+  width: 100vw;
+  left: @leftbar-width;
+  height: @topbar-height;
+  padding-left: 1rem;
+  line-height: @topbar-height;
 }

--- a/geoportailv3/templates/index.html
+++ b/geoportailv3/templates/index.html
@@ -37,6 +37,8 @@
           </div>
         </div>
 
+        <div class="offline-msg alert-danger" translate>You are currently offline.</div>
+
         <ul class="nav navbar-nav pull-right">
           <li class="visible-xs-inline-block search icon" ng-click="mainCtrl.mobileSearchActive = true"><a href translate>search</a></li>
           <li ng-click="mainCtrl.toggleThemeSelector();">
@@ -80,7 +82,6 @@
     </div>
     <!-- Begin page content (ie. map + left sidebar) -->
     <div id="main-container">
-      <div class="offline-msg alert-danger" translate>You are currently offline.</div>
       <div id="sidebar" ng-class="{open: mainCtrl.sidebarOpen()}"
            app-resizemap="mainCtrl.map" app-resizemap-state="mainCtrl.sidebarOpen()">
 


### PR DESCRIPTION
GSLUX-89

Better CSS / other position for offline-warning message.
Before, it pushed all the page to the bottom (creates problems with the map and the footer)

Now, it looks like this (there is no more element to click on the top bar anyway):
![selection_006](https://user-images.githubusercontent.com/1792111/41701851-482e1eba-752e-11e8-89de-abf800c4794a.png)
