### PR TITLE
Add custom configuration for offline layers

### DIFF
--- a/geoportailv3/static/js/appmodule.js
+++ b/geoportailv3/static/js/appmodule.js
@@ -11,7 +11,7 @@ goog.require('ngeo.misc.sortableComponent');
 goog.require('ngeo.statemanager.module');
 goog.require('ngeo.search.module');
 goog.require('ngeo.offline.module');
-goog.require('ngeo.offline.DefaultConfiguration');
+goog.require('app.offline.DefaultConfiguration');
 goog.require('ol.has');
 
 goog.require('ngeo.olcs.olcsModule');
@@ -57,7 +57,7 @@ app.module.config(['$sceDelegateProvider', function($sceDelegateProvider) {
 }]);
 
 // Define the offline download configuration service
-app.module.service('ngeoOfflineConfiguration', ngeo.offline.DefaultConfiguration);
+app.module.service('ngeoOfflineConfiguration', app.offline.DefaultConfiguration);
 
 /**
  * @param {string} name The string to sanitize.

--- a/geoportailv3/static/js/offline/defaultConfiguration.js
+++ b/geoportailv3/static/js/offline/defaultConfiguration.js
@@ -54,6 +54,17 @@ exports = class extends NgeoConfiguration {
     return results;
   }
 
+  /**
+   * @override
+   * @param {ol.Map} map The map to work on.
+   * @param {ol.Extent} userExtent The extent selected by the user.
+   * @return {!Array<ngeox.OfflineLayerMetadata>} the downloadable layers and metadata.
+   */
+  createLayerMetadatas(map, userExtent) {
+    const layersItems = super.createLayerMetadatas(map, userExtent);
+    return layersItems.filter(item => item.type === 'tile');
+  }
+
   isBgLayer_(layer, map) {
     return layer === this.backgroundLayerMgr_.get(map);
   }

--- a/geoportailv3/static/js/offline/defaultConfiguration.js
+++ b/geoportailv3/static/js/offline/defaultConfiguration.js
@@ -1,0 +1,60 @@
+goog.module('app.offline.DefaultConfiguration');
+goog.module.declareLegacyNamespace();
+
+goog.require('ngeo.map.BackgroundLayerMgr');
+
+const NgeoConfiguration = goog.require('ngeo.offline.DefaultConfiguration');
+
+/**
+ * @implements {ngeox.OfflineConfiguration}
+ */
+exports = class extends NgeoConfiguration {
+
+  /**
+   * @ngInject
+   * @param {!angular.Scope} $rootScope The rootScope provider.
+   * @param {ngeo.map.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer
+   *     manager.
+   */
+  constructor($rootScope, ngeoBackgroundLayerMgr) {
+    super($rootScope);
+
+    /**
+     * @type {ngeo.map.BackgroundLayerMgr}
+     * @private
+     */
+    this.backgroundLayerMgr_ = ngeoBackgroundLayerMgr;
+  }
+
+  /**
+   * @override
+   * @param {ol.Map} map
+   * @param {ol.layer.Layer} layer
+   * @param {Array<ol.layer.Group>} ancestors
+   * @param {ol.Extent} userExtent The extent selected by the user.
+   * @return {Array<ngeox.OfflineExtentByZoom>}
+   */
+  getExtentByZoom(map, layer, ancestors, userExtent) {
+    const currentZoom = map.getView().getZoom();
+    const viewportExtent = map.getView().calculateExtent(map.getSize());
+
+    const extent = this.isBgLayer_(layer, map) ? viewportExtent : userExtent;
+    const zoomRange = [0, 1, 2, 3, 4].map(dz => dz + currentZoom);
+    const zooms = this.isBgLayer_(layer, map) ?
+      [8, 9, 10, 11, 12, 13, 14, 15, ...zoomRange.filter(dz => dz > 15)] :
+      zoomRange;
+
+    const results = [];
+    zooms.forEach((dz) => {
+      results.push({
+        zoom: dz,
+        extent: extent
+      });
+    });
+    return results;
+  }
+
+  isBgLayer_(layer, map) {
+    return layer === this.backgroundLayerMgr_.get(map);
+  }
+};


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSLUX-85

Define a custom offline configuration to specify behavior of layer downloading.
Find specs in https://jira.camptocamp.com/browse/GSLUX-83

```
When the menu is opened at a level < 11, it will zoom to level 11
When the menu is opened at a level > 15 it will zoom to level 15
The rectangle will take the current extent of the screen 
(minus a 10% buffer so that it can be greyed out)

If the current view contains a background map (member of group bglayers),
 it should always be downloaded for the whole mapviewer extent from level 8-13
 and further down according to the rules specified through the extent of 
the download area
```
