### PR TITLE
Fix appcache allcategories retrieving

### DIFF
--- a/geoportailv3/templates/geoportailv3.appcache
+++ b/geoportailv3/templates/geoportailv3.appcache
@@ -32,5 +32,5 @@ NETWORK:
 FALLBACK:
 /theme/main /theme/main
 /themes ${request.route_url('themes', _query={'version': '2', 'background': 'bglayers', 'interface': 'desktop', 'catalogue': 'true', 'min_levels': '1'})}
-/mymaps/allcategories /mymaps/allcategories
+${request.route_url('mymaps_getallcategories')} ${request.route_url('mymaps_getallcategories')}
 /predefined_wms /predefined_wms


### PR DESCRIPTION
This fix the error in the Chrome console relative to allcategories retrieving:

![image](https://user-images.githubusercontent.com/7294662/46602794-801b4500-caf1-11e8-9706-ae89674696bc.png)