### PR TITLE
Update pip, CairoSVG doesn't build with pip 8

### DIFF
--- a/CONST_Makefile
+++ b/CONST_Makefile
@@ -702,7 +702,7 @@ $(VENV_BIN)/flake8: .build/dev-requirements.timestamp
 	mkdir -p $(dir $@)
 	virtualenv --setuptools --no-site-packages .build/venv
 	$(PIP_CMD) install \
-		'pip==7.1.2' 'setuptools==21.0.0'
+		'pip==19.0.2' 'setuptools==21.0.0'
 	touch $@
 
 .build/requirements.timestamp: $(EGGS_DEPENDENCIES)


### PR DESCRIPTION
@gberaudo Should I merge it into master ?

See: https://github.com/Kozea/CairoSVG/issues/232

Stack trace without this fix:
```
...
Collecting cairocffi (from CairoSVG==1.0.22->geoportailv3==1.0->-r CONST_requirements.txt (line 9))
  Using cached https://files.pythonhosted.org/packages/33/33/a6aac7bace71019712fbc34f4ceb9d90c23f8fbadf2ac48f771aef9c1431/cairocffi-1.0.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-vGk2u3/cairocffi/setup.py", line 7, in <module>
        'cairocffi does not support Python 2.x anymore. '
    RuntimeError: cairocffi does not support Python 2.x anymore. Please use Python 3 or install an older version of cairocffi.
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-vGk2u3/cairocffi
You are using pip version 7.1.2, however version 19.0.2 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
CONST_Makefile:709: recipe for target '.build/requirements.timestamp' failed
make: *** [.build/requirements.timestamp] Error 1

```