### PR TITLE
Offline

### DIFF
--- a/geoportal/geoportailv3_geoportal/__init__.py
+++ b/geoportal/geoportailv3_geoportal/__init__.py
@@ -404,6 +404,12 @@ def main(global_config, **settings):
     config.add_route('isthemeprivate', '/isthemeprivate')
     config.add_route('download_resource', '/downloadresource')
 
+    # Service worker
+    config.add_route(
+        'sw',
+        '/sw.js'
+    )
+
     # Appcache manifest
     config.add_route(
         'appcache',

--- a/geoportal/geoportailv3_geoportal/lib/sw_helper.py
+++ b/geoportal/geoportailv3_geoportal/lib/sw_helper.py
@@ -19,11 +19,17 @@ def get_urls(request):
         '/',
         '/dynamic.js?interface=main',
         '/getuserinfo',
+        '/themes?version=2&background=background&interface=main&catalogue=true&min_levels=1',
         request.static_path('geoportailv3_geoportal:static-ngeo/images/arrow.png'),
         main_js_url,
         main_css_url,
         gov_light_url
     ]
+
+    if 'dev' in request.params:
+        urls.append('/dev/main.html')
+        urls.append('/dev/main.css')
+        urls.append('/dev/main.js')
 
     woffs = glob.glob('/app/geoportailv3_geoportal/static-ngeo/build/*.woff')
     for stuff in get_built_filenames('*.woff'):

--- a/geoportal/geoportailv3_geoportal/lib/sw_helper.py
+++ b/geoportal/geoportailv3_geoportal/lib/sw_helper.py
@@ -1,0 +1,35 @@
+import os
+import glob
+import time
+
+UNUSED = '/static-ngeo/UNUSED_CACHE_VERSION/build/'
+BUILD_PATH = '/app/geoportailv3_geoportal/static-ngeo/build'
+
+
+def get_built_filenames(pattern):
+    return [os.path.basename(name) for name in glob.glob(BUILD_PATH + '/' + pattern)]
+
+
+def get_urls(request):
+    main_js_url = UNUSED + get_built_filenames('main.*.js')[0]
+    main_css_url = UNUSED + get_built_filenames('main.*.css')[0]
+    gov_light_url = UNUSED + get_built_filenames('gov-light.*.png')[0]
+
+    urls = [
+        '/',
+        '/dynamic.js?interface=main',
+        '/getuserinfo',
+        request.static_path('geoportailv3_geoportal:static-ngeo/images/arrow.png'),
+        main_js_url,
+        main_css_url,
+        gov_light_url
+    ]
+
+    woffs = glob.glob('/app/geoportailv3_geoportal/static-ngeo/build/*.woff')
+    for stuff in get_built_filenames('*.woff'):
+        urls.append(UNUSED + stuff)
+
+    for lang in ['fr', 'en', 'lb', 'de']:
+        urls.append(request.static_path('geoportailv3_geoportal:static-ngeo/build/' + lang + '.json'))
+
+    return urls

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/OfflineRestorer.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/OfflineRestorer.js
@@ -4,6 +4,7 @@
 import appModule from './module.js';
 import Restorer from 'ngeo/offline/Restorer.js';
 
+
 /**
  * @extends {Restorer}
  */
@@ -14,9 +15,10 @@ const OfflineRestorer = class extends Restorer {
    * @param {ngeo.map.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer manager.
    * @param {app.MymapsOffline} appMymapsOffline mymaps offline service.
    * @param {app.draw.DrawnFeatures} appDrawnFeatures Drawn features service.
+   * @param {import('./offline/MapboxOffline').default} appMapBoxOffline The MapBox offline service.
    */
   constructor(ngeoOfflineConfiguration, ngeoBackgroundLayerMgr,
-              appMymapsOffline, appDrawnFeatures) {
+              appMymapsOffline, appDrawnFeatures, appMapBoxOffline) {
     super(ngeoOfflineConfiguration, ngeoBackgroundLayerMgr);
     /**
      * @type {app.MymapsOffline}
@@ -29,6 +31,10 @@ const OfflineRestorer = class extends Restorer {
      * @type {app.draw.DrawnFeatures}
      */
     this.appDrawnFeatures_ = appDrawnFeatures;
+
+    this.appMapBoxOffline_ = appMapBoxOffline;
+
+    this.ngeoBackgroundLayerMgr_ = ngeoBackgroundLayerMgr;
 
     /**
      * @type {boolean}
@@ -43,8 +49,20 @@ const OfflineRestorer = class extends Restorer {
    */
   restore(map) {
     this.restoring = true;
+    const bgLayer = this.ngeoBackgroundLayerMgr_.get(map);
     return super.restore(map).then((extent) => {
+      // Keep a reference to the original mapbox layer
+      let mapBoxLayer = null;
+      if (bgLayer.getMapBoxMap) {
+        mapBoxLayer = bgLayer;
+      }
+
       this.appMymapsOffline_.restore();
+      if (mapBoxLayer) {
+        console.log('Restoring MapBox');
+        this.appMapBoxOffline_.restore(mapBoxLayer.getMapBoxMap());
+        this.ngeoBackgroundLayerMgr_.set(map, mapBoxLayer);
+      }
       map.addLayer(this.appDrawnFeatures_.drawLayer);
       this.restoring = false;
       return extent;

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/OfflineRestorer.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/OfflineRestorer.js
@@ -60,7 +60,7 @@ const OfflineRestorer = class extends Restorer {
       this.appMymapsOffline_.restore();
       if (mapBoxLayer) {
         console.log('Restoring MapBox');
-        this.appMapBoxOffline_.restore(mapBoxLayer.getMapBoxMap());
+        this.appMapBoxOffline_.restore(mapBoxLayer);
         this.ngeoBackgroundLayerMgr_.set(map, mapBoxLayer);
       }
       map.addLayer(this.appDrawnFeatures_.drawLayer);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -249,6 +249,13 @@ const MainController = function(
   appMymaps.setOfflineMode(ngeoOfflineMode);
   appMymaps.setOfflineService(appMymapsOffline);
 
+  if (navigator.serviceWorker) {
+    // Force online state on load since iOS/Safari does not support clientIds.
+    navigator.serviceWorker.getRegistration().then(() => {
+      fetch('/switch-lux-online');
+    })
+  }
+
   /**
    * @type {string}
    * @private

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang={{mainCtrl.lang}} ng-app="Appmain" ng-controller="MainController as mainCtrl" manifest="/geoportailv3.appcache">
+<html lang={{mainCtrl.lang}} ng-app="Appmain" ng-controller="MainController as mainCtrl">
   <head>
     <title ng-bind-template="{{ mainCtrl.getCurrentTheme()|translate }}{{ ' - Geoportal Luxembourg'|translate}}"></title>
     <meta charset="utf-8">
@@ -21,6 +21,13 @@
     <link rel="apple-touch-icon-precomposed" sizes="57x57" href="https://www.geoportail.lu/static/images/apple-icon-57x57-precomposed.png" />
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://www.geoportail.lu/static/images/apple-icon-72x72-precomposed.png" />
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://www.geoportail.lu/static/images/apple-icon-114x114-precomposed.png" />
+    <script>
+        if('serviceWorker' in navigator) {
+          navigator.serviceWorker
+            .register('/sw.js')
+            .then(function() { console.log("Service Worker Registered"); });
+        }
+    </script>
   </head>
 
   <body data-theme="{{mainCtrl.getEncodedCurrentTheme()}}" ng-class="{'offline-or-disconnected': mainCtrl.isDisconnectedOrOffline(), 'search-mobile': mainCtrl.mobileSearchActive, 'enabled-3d': mainCtrl.is3dEnabled()}">

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -22,9 +22,10 @@
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://www.geoportail.lu/static/images/apple-icon-72x72-precomposed.png" />
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://www.geoportail.lu/static/images/apple-icon-114x114-precomposed.png" />
     <script>
-        if('serviceWorker' in navigator) {
+        var dev = document.location.href.indexOf('dev/main') !== -1;
+        if ('serviceWorker' in navigator) {
           navigator.serviceWorker
-            .register('/sw.js')
+            .register('/sw.js' + (dev ? '?dev' : ''))
             .then(function() { console.log("Service Worker Registered"); });
         }
     </script>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -43,7 +43,7 @@
 
         <div class="offline-msg alert-danger" translate>
           <span ng-if="!mainCtrl.offlineMode.isEnabled()">You are currently disconnected.
-            <a ng-click="mainCtrl.offlineMode.activateOfflineMode()" ng-if="mainCtrl.offlineMode.hasData()" translate>Enable offline mode</a>
+            <a href ng-click="mainCtrl.offlineMode.activateOfflineMode()" ng-if="mainCtrl.offlineMode.hasData()" translate>Enable offline mode</a>
           </span>
           <span ng-if="mainCtrl.offlineMode.isEnabled()">You are currently offline.</span>
         </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/module.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/module.js
@@ -32,6 +32,7 @@ import ngeoSearchModule from 'ngeo/search/module.js';
 import ngeoStatemanagerLocation from 'ngeo/statemanager/Location.js';
 import ngeoStatemanagerModule from 'ngeo/statemanager/module.js';
 import ngeoStatemanagerWfsPermalink from 'ngeo/statemanager/WfsPermalink.js';
+import MapBoxOffline from './offline/MapboxOffline.js';
 
 const fakeGmfAbstractAppControllerModule = angular.module('GmfAbstractAppControllerModule', []);
 
@@ -97,6 +98,9 @@ exports.config(['$sceDelegateProvider', function($sceDelegateProvider) {
 
 // Define the offline download configuration service
 exports.service('ngeoOfflineConfiguration', appOfflineConfiguration);
+
+// Define the offline download configuration service
+exports.service('appMapBoxOffline', MapBoxOffline);
 
 exports.config(['$httpProvider', function($httpProvider) {
   $httpProvider.interceptors.push('noCacheInterceptor');

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
@@ -30,14 +30,6 @@ function blobToDataUrl(blob) {
 }
 
 
-
-function boundsToExtent(bounds) {
-  const sw = fromLonLat(bounds.getSouthWest().toArray())
-  const ne = fromLonLat(bounds.getNorthEast().toArray())
-  return [...sw, ...ne];
-}
-
-
 function storeData(dbPromise, url, dataUrl) {
   return dbPromise.then(db => new Promise((resolve, reject) => {
     const objectStore = db.transaction(["responses"], "readwrite").objectStore("responses");
@@ -82,9 +74,6 @@ function fetchBlobsAndStore(urls, progressCallback) {
     })
   }));
 }
-
-  // const offlineStyle = map.getStyle();
-  // const extent = boundsToExtent(map.getBounds());
 
 
 export default class MapBoxOffline {
@@ -132,8 +121,6 @@ export default class MapBoxOffline {
         tileGrid.forEachTileCoord(extent, zoom, coord => {
           const url = tileUrlFunction(coord, devicePixelRatio, projection);
           urls.push(url);
-          console.log(url);
-          // const tile = {coord, url, response: null};
         });
       }
     }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
@@ -170,13 +170,20 @@ export default class MapBoxOffline {
     this.getUrlsPromise(style, extentByZoom).then(urls => fetchBlobsAndStore(urls, progressCallback)));
   }
 
-  restore(map) {
+  restore(layer) {
     console.log('Activate MapBox offline data');
+    const map = layer.getMapBoxMap();
     if (!navigator.serviceWorker.controller) {
       alert('You must reload the page before entering offline mode');
     }
     fetch('/switch-lux-offline').then(() => {
-      const style = map.getStyle();
+      let style;
+      try {
+        style = map.getStyle();
+      } catch (e) {
+        console.log('No defined style, using default one');
+        style = layer.get('defaultMapBoxStyle');
+      }
       map.setStyle(null);
       map.setStyle(style);
     }, 0);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
@@ -188,11 +188,7 @@ export default class MapBoxOffline {
     if (!navigator.serviceWorker.controller) {
       alert('You must reload the page before entering offline mode');
     }
-    navigator.serviceWorker.controller.postMessage({
-      offline: true
-    })
-    setTimeout(() => {
-      // I guess we must wait a bit??
+    fetch('/switch-lux-offline').then(() => {
       const style = map.getStyle();
       map.setStyle(null);
       map.setStyle(style);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/MapboxOffline.js
@@ -1,0 +1,201 @@
+import {XYZ} from 'ol/source';
+import {fromLonLat, transformExtent} from 'ol/proj';
+
+
+// Copied from worker!
+const dbPromise = new Promise((resolve, reject) => {
+  const request = indexedDB.open("swdb", 1);
+  request.onsuccess = evt => resolve(evt.target.result);
+  request.onerror = reject;
+  request.onupgradeneeded = function(event) {
+    const db = event.target.result;
+    db.createObjectStore("responses", { keyPath: "url" });
+  };
+});
+
+
+/**
+ * @param {!Blob} blob A blob
+ * @return {Promise<string>} data URL
+ */
+function blobToDataUrl(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = function() {
+      resolve(/** @type {String} */(reader.result));
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+
+
+function boundsToExtent(bounds) {
+  const sw = fromLonLat(bounds.getSouthWest().toArray())
+  const ne = fromLonLat(bounds.getNorthEast().toArray())
+  return [...sw, ...ne];
+}
+
+
+function storeData(dbPromise, url, dataUrl) {
+  return dbPromise.then(db => new Promise((resolve, reject) => {
+    const objectStore = db.transaction(["responses"], "readwrite").objectStore("responses");
+    const request = objectStore.get(url);
+    request.onerror = reject;
+    request.onsuccess = function(event) {
+      let data = event.target.result;
+      if (data) {
+        data.content = dataUrl;
+        const requestUpdate = objectStore.put(data);
+        requestUpdate.onsuccess = resolve;
+        requestUpdate.onerror = reject;
+      } else {
+        data = {
+          content: dataUrl,
+          url
+        };
+        const requestInsert = objectStore.add(data);
+        requestInsert.onsuccess = resolve;
+        requestInsert.onerror = reject;
+      }
+    };
+  }));
+}
+
+function fetchAndStoreResponseHelper(url, clone) {
+  let response;
+  return fetch(url)
+    .then(r => (response = (clone ? r.clone() : null), r.blob()))
+    .then(blob => blobToDataUrl(blob))
+    .then(dataUrl => storeData(dbPromise, url, dataUrl))
+    .then(() => response);
+}
+
+function fetchBlobsAndStore(urls, progressCallback) {
+  let count = 0;
+  return Promise.all(urls.map(url => {
+    return fetchAndStoreResponseHelper(url)
+    .finally(() => {
+        ++count;
+        progressCallback(count / urls.length);
+    })
+  }));
+}
+
+  // const offlineStyle = map.getStyle();
+  // const extent = boundsToExtent(map.getBounds());
+
+
+export default class MapBoxOffline {
+  getGlyphUrls(style) {
+    const glyphs = style.glyphs;
+
+    // Get glyphs config
+    const fontstacks = new Set();
+    for (const layer of style.layers) {
+      const layout = layer.layout;
+      if (layout && layout['text-font']) {
+        fontstacks.add(...layout['text-font']);
+      }
+    }
+    const ranges = ['0-255', '256-511'];
+    const fontUrls = [];
+    for (const fontstack of fontstacks) {
+      for (const range of ranges) {
+        fontUrls.push(glyphs.replace('{fontstack}', fontstack).replace('{range}', range));
+      }
+    }
+
+    return fontUrls;
+  }
+
+  getTileUrls(sources, extentByZoom) {
+    const projection = 'EPSG:3857';
+    const devicePixelRatio = navigator.devicePixelRatio;
+    const urls = [];
+    for (const name in sources) {
+      const source = sources[name];
+      const {type, tileSize, url} = source;
+      const xyz = new XYZ({
+        url,
+        tileSize
+      });
+      const tileGrid = xyz.getTileGrid();
+      const tileUrlFunction = xyz.getTileUrlFunction();
+      const doneZooms = {};
+      for (const zoomExtent of extentByZoom) {
+        const {zoom, extent} = zoomExtent;
+        if (zoom < source.minzoom || zoom > source.maxzoom) {
+          continue;
+        }
+        tileGrid.forEachTileCoord(extent, zoom, coord => {
+          const url = tileUrlFunction(coord, devicePixelRatio, projection);
+          urls.push(url);
+          console.log(url);
+          // const tile = {coord, url, response: null};
+        });
+      }
+    }
+    return urls;
+  }
+
+
+  getSourcesPromise(style) {
+    const sourceUrls = [];
+    for (const name in style.sources) {
+      const url = style.sources[name].url;
+      sourceUrls.push(url);
+    }
+
+    const promises = sourceUrls.map(url =>
+      fetch(url).then(r => r.json())
+      .then(source => this.saveJsonContent_(url, source))
+      .then(source => {
+      const {bounds, format, maxzoom, minzoom, pixel_scale, tiles} = source;
+      return {
+        extent: transformExtent(bounds, 'EPSG:4326', 'EPSG:3857'),
+        format,
+        maxzoom,
+        minzoom,
+        url: tiles[0],
+        tileSize: pixel_scale || 256
+      }
+    }));
+    return Promise.all(promises);
+  }
+
+  getUrlsPromise(style, extentByZoom) {
+    const glyphUrls = this.getGlyphUrls(style);
+    
+    return this.getSourcesPromise(style).then(sources => this.getTileUrls(sources, extentByZoom)).then(sourceUrls => [
+      ...glyphUrls, ...sourceUrls
+    ]);
+  }
+
+  saveJsonContent_(url, json) {
+    return storeData(dbPromise, url, JSON.stringify(json, null, 2)).then(() => json);
+  }
+
+  save(styleUrl, style, extentByZoom, progressCallback) {
+    console.log('Saving MapBox data');
+    return this.saveJsonContent_(styleUrl, style).then(() =>
+    this.getUrlsPromise(style, extentByZoom).then(urls => fetchBlobsAndStore(urls, progressCallback)));
+  }
+
+  restore(map) {
+    console.log('Activate MapBox offline data');
+    if (!navigator.serviceWorker.controller) {
+      alert('You must reload the page before entering offline mode');
+    }
+    navigator.serviceWorker.controller.postMessage({
+      offline: true
+    })
+    setTimeout(() => {
+      // I guess we must wait a bit??
+      const style = map.getStyle();
+      map.setStyle(null);
+      map.setStyle(style);
+    }, 0);
+  }
+}

--- a/geoportal/geoportailv3_geoportal/templates/sw.js
+++ b/geoportal/geoportailv3_geoportal/templates/sw.js
@@ -1,0 +1,19 @@
+<%
+  from geoportailv3_geoportal.lib.sw_helper import get_urls
+  urls = get_urls(request)
+%>
+% if 'no_service_worker' in request.registry.settings:
+  self.registration.unregister();
+  return;
+% endif
+
+const urls = [
+  // '/dev/main.html',
+  // '/dev/main.css',
+  // '/dev/main.js',
+% for url in urls:
+  '${url}',
+% endfor
+];
+
+<%include file="sw_content.js" />

--- a/geoportal/geoportailv3_geoportal/templates/sw.js
+++ b/geoportal/geoportailv3_geoportal/templates/sw.js
@@ -8,9 +8,6 @@
 % endif
 
 const urls = [
-  // '/dev/main.html',
-  // '/dev/main.css',
-  // '/dev/main.js',
 % for url in urls:
   '${url}',
 % endfor

--- a/geoportal/geoportailv3_geoportal/templates/sw_content.js
+++ b/geoportal/geoportailv3_geoportal/templates/sw_content.js
@@ -1,0 +1,116 @@
+let offlineEnabled = false;
+
+/**
+ * Normalise URL so that it can be used as key in the cache.
+ * Remove:
+ * - the domain name
+ * - port;
+ * - search and hash;
+ * - "/theme/main"
+ * @param {string} url
+ */
+function normalizeUrl(url) {
+  if (url.startsWith('http')) {
+    const idx = url.substr(9).indexOf('/');
+    url = url.substr(9 + idx);
+  }
+  let i = url.indexOf('?');
+  if (i !== -1) {
+    url = url.substr(0, i);
+  }
+  j = url.indexOf('#');
+  if (i !== -1) {
+    url = url.substr(0, i);
+  }
+  const horrorSuffix = '/theme/main';
+  if (url.endsWith(horrorSuffix)) {
+    url = url.substr(0, url.length - horrorSuffix.length);
+  }
+
+  if (!url) {
+    url = '/';
+  }
+  return url;
+}
+
+
+/**
+ * Fetch the resource and store it in the cache using a normalized key.
+ * @param {Cache} cache The cache object to use.
+ * @param {string} url A plain string URL
+ */
+async function getAndCacheUrl(cache, url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new TypeError('Bad response status ' + url + ' ' + response.status);
+  }
+
+  url = normalizeUrl(url);
+  return cache.put(url, response);
+}
+
+/**
+ * Download website file for offline usage.
+ * The files are stored in a cache and will be served from there.
+ */
+async function downloadAndCacheWebsiteFiles() {
+  console.log("Start downloading website files for offline");
+  const cache = await caches.open('offlinewebsite');
+  const promise = Promise.all(
+    urls.map(url => getAndCacheUrl(cache, url))
+  )
+  promise.then(
+    () => console.log('all files fetched and cached successfuly'),
+    () => console.error('some file could not be fetched or cached')
+  );
+  return promise;
+}
+
+
+/**
+ * Normalize the passed URL and look for a response inside the cache
+ * Return `undefined` if no response was found.
+ * @param {string} url
+ * @return {Promise<Response|undefined>}
+ */
+function getCachedFile(url) {
+  url = normalizeUrl(url);
+  return caches.open('offlinewebsite').then(
+    cache => cache.match(url, {
+      ignoreSearch: true,
+  }));
+}
+
+
+if (typeof self === 'object') {
+  console.log('In the sw');
+  self.addEventListener('install', e => {
+    console.log('SW installation');
+    e.waitUntil(downloadAndCacheWebsiteFiles());
+  });
+
+  // Intercept the network queries from the main thread and the workers
+  // This is necessary:
+  // - to serve the website without network connectivity;
+  // - to inject offline MVT data into MapBox without modifying MapBox.
+  self.addEventListener('fetch', function(event) {
+    // console.log('sw intercept fetch', event.request.url)
+    // TODO:
+    // should normalize the url
+    // if in the website files => fetch in the cache (and forward fetch if not found?)
+    // if offline enabled
+    // -> get from the indexedDb (no fallback)
+    event.respondWith(
+        getCachedFile(event.request.url).then(response => response || fetch(event.request))
+    );
+  });
+
+  // Listen for messages from the applications
+  // This is used to toggle the "offline mode".
+  self.addEventListener('message', function(event) {
+    if ('offline' in event.data) {
+      offlineEnabled = !!event.data.offline;
+      console.log('Offline is now', offlineEnabled);
+    }
+  });
+}

--- a/geoportal/geoportailv3_geoportal/templates/sw_content.js
+++ b/geoportal/geoportailv3_geoportal/templates/sw_content.js
@@ -125,13 +125,11 @@ function dataURItoBlob(dataURI) {
 function readFromIndexedDB(db, url) {
   url = decodeURI(url);
   return new Promise((resolve, reject) => {
-    console.log('indexedDB is up, cool!');
     const dbRequest = db.transaction("responses").objectStore("responses").get(url);
     dbRequest.onsuccess = function(dbEvent) {
       const init = {"status" : 200 , "statusText" : "OK"};
       const result = dbEvent.target.result;
       if (result && result.content) {
-        console.log('found content! for ' + url);
         let d = result.content
         if (d.startsWith('data')) {
           d = dataURItoBlob(d);
@@ -174,7 +172,7 @@ if (typeof self === 'object') {
     const switchOnline = url.includes('/switch-lux-online');
     if (switchOffline || switchOnline) {
       const value = offlineEnabled[event.clientId] = switchOffline;
-      console.log('Offline of ', event.clientId, 'is now', value);
+      console.log('Offline of mode of client', event.clientId, 'is now', value);
       const promise = Promise.resolve(new Response(value.toString()));
       event.respondWith(promise);
       return;
@@ -199,14 +197,5 @@ if (typeof self === 'object') {
     // In all other cases forward to network
     // if in the website files => fetch in the cache (and forward fetch if not found?)
     event.respondWith(fetch(event.request));
-  });
-
-  // Listen for messages from the applications
-  // This is used to toggle the "offline mode".
-  self.addEventListener('message', function(event) {
-    if ('offline' in event.data) {
-      offlineEnabled[event.clientId] = !!event.data.offline;
-      console.log('Offline is now', offlineEnabled);
-    }
   });
 }

--- a/geoportal/geoportailv3_geoportal/views/sw.py
+++ b/geoportal/geoportailv3_geoportal/views/sw.py
@@ -1,0 +1,10 @@
+from pyramid.view import view_config
+import logging
+
+log = logging.getLogger(__name__)
+
+
+@view_config(route_name='sw', http_cache=0, renderer='../templates/sw.js')
+def appcache(request):
+    request.response.content_type = 'application/javascript'
+    return {}


### PR DESCRIPTION
- replace appcache with service worker since it will be removed in Firefox in the coming months; files are put in the browser "cache";
- store MapBoxVectorTiles content in indexedDB so that it can be used while offline. This uses browser storage;
- handle switching to offline mode. Due to Safari lacking some APIs, there are some limitations for Safari.

It was not tested with the smartphone apps. It looks like there may be some shortcomings or issues:
- Android: should work using the browser storage for MVT content;
- iOS: *Service Workers requires an entitlement config* and might not work, see https://stackoverflow.com/questions/49673399/service-workers-unavailable-in-wkwebview-in-ios-11-3. Otherwise it should work using the browser storage for MVT content.

Notes:
- Android allows to intercept Service Worker calls, so we could, in theory, implement device storage.