### PR TITLE
Save medium styles when changing simple styles

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -355,7 +355,8 @@ const MainController = function(
       item.color = colors[idx];
       item.visible = true;
       return item;
-    })
+    });
+    this.debouncedSaveMediumStyle_();
   };
 
   const mediumStyle = appMvtStylingService.getMediumStyle();


### PR DESCRIPTION
Save medium "fields" style at the same time when simple styles are changed to avoid desynchronization.

Initial use case was that changing simple style, while having medium style in local storage, was not saved and loaded when reloading the page and kept visible the old medium style instead. This is because the medium styles was not updated in the local storage and was keeping old version.