### PR TITLE
Render measure in print.

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -799,6 +799,13 @@ const MainController = function(
   this['selectedLayers'] = [];
 
   /**
+   * @type {function}
+   */
+  this['selectedLayersLength'] = function() {
+    return this['selectedLayers'].filter(l => !l.get('metadata').hidden).length
+  }
+
+  /**
    * @type {Array}
    */
   this['ageLayers'] = [];

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -801,8 +801,8 @@ const MainController = function(
   /**
    * @type {function}
    */
-  this['selectedLayersLength'] = function() {
-    return this['selectedLayers'].filter(l => !l.get('metadata').hidden).length
+  this.selectedLayersLength = function() {
+    return this.selectedLayers.filter(l => !l.get('metadata').hidden).length
   }
 
   /**

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -115,7 +115,7 @@
             <li role="presentation" class="my-layers-tab">
               <a href="#mylayers" data-toggle="tab">
                 <span translate>my_layers</span>
-                <span ng-if="mainCtrl.selectedLayers.length > 0">({{mainCtrl.selectedLayers.length}})</span>
+                <span ng-if="mainCtrl.selectedLayersLength() > 0">({{mainCtrl.selectedLayersLength()}})</span>
               </a>
             </li>
             <li role="presentation" class="active catalog-tab">

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/layermanager/layermanager.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/layermanager/layermanager.html
@@ -1,6 +1,6 @@
 <div ng-if="!ctrl.layers.length" translate>No layer selected</div>
 <ul id="layermanager-{{::ctrl.uid}}" class="layermanager" ngeo-sortable="ctrl.layers" ngeo-sortable-callback="ctrl.reorderCallback" ngeo-sortable-options="{handleClassName: 'sortable-handle', draggerClassName: 'sortable-dragger'}" >
-  <li ng-repeat="layer in ctrl.layers" class="panel layermanager-panel">
+  <li ng-repeat="layer in ctrl.layers" class="panel layermanager-panel" ng-if="!layer.get('metadata').hidden">
   <span class="sortable-handle fa fa-reorder"></span>
     <app-layerinfo app-layerinfo-layer="::layer"></app-layerinfo>
     <div data-toggle="collapse" data-parent="#layermanager-{{::ctrl.uid}}" data-target="#layermanager-item-{{$index}}" class="layer-label">

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
@@ -180,7 +180,7 @@ const exports = function($scope, $q, $http, $compile, gettext,
     text: new olStyleText({
       font: 'bold 12px Calibri,sans-serif',
       fill: new olStyleFill({
-        color: 'rgb(0 0 0 / 100)'
+        color: 'rgb(0 0 0)'
       }),
       stroke: new olStyleStroke({
         color: 'rgba(255, 204, 51, 1)',

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
@@ -121,18 +121,15 @@ const exports = function($scope, $q, $http, $compile, gettext,
     return text.startsWith('NaN') ? '' : text
   }
   const generateStyle = baseStyle => f => {
-    const style = baseStyle.clone()
     const geomType = f.getGeometry().getType()
-    style.getText().setText('')
 
     if (['Point', 'Circle'].includes(geomType)) {
-      style.getText().setText('')
-      return style;
+      return baseStyle;
     }
     if (this['measureArea'].getActive() && (geomType !== 'Polygon')) {
-      style.getText().setText('')
-      return style;
+      return baseStyle;
     }
+    const style = baseStyle.clone()
 
     let text = this[
       this['measureLength'].getActive() ? 'measureLength' :
@@ -235,7 +232,6 @@ const exports = function($scope, $q, $http, $compile, gettext,
     style: style
   })
   var features = []
-  window.map = this.map_
   this.map_.addLayer(layer)
   // layer.getSource().on('addfeature', e => features.push(e.feature))
   // layer.getSource().on('clear', () => layer.getSource().addFeatures(features))

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
@@ -191,6 +191,14 @@ const exports = function($scope, $q, $http, $compile, gettext,
   });
   var style = generateStyle(style_)
 
+  const layer = new olLayerVector({
+    source: new olSourceVector(),
+    style: style,
+    metadata: {
+      hidden: true
+    }
+  })
+  this.map_.addLayer(layer)
 
   var helpMsg = gettext('Click to start drawing profile');
   var contMsg = gettext('Click to continue drawing the line<br>' +
@@ -240,14 +248,6 @@ const exports = function($scope, $q, $http, $compile, gettext,
   helpMsg = gettext('Click to start drawing area');
   contMsg = gettext('Click to continue drawing the polygon<br>' +
       'Double-click or click last point to finish');
-  const layer = new olLayerVector({
-    source: new olSourceVector(),
-    style: style,
-    metadata: {
-      hidden: true
-    }
-  })
-  this.map_.addLayer(layer)
 
   /**
    * @type {ol.layer.Vector}

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
@@ -31,6 +31,7 @@ import olStyleStyle from 'ol/style/Style.js';
 import olLayerVector from 'ol/layer/Vector.js';
 import olSourceVector from 'ol/source/Vector.js';
 import olFeature from 'ol/Feature.js';
+import { fromCircle } from 'ol/geom/Polygon';
 
 
 /**
@@ -131,12 +132,15 @@ const exports = function($scope, $q, $http, $compile, gettext,
     }
     // Clone style because text style should not be shared
     const style = baseStyle.clone()
-    const getCollectionStyle = s => {
+    const getCollectionStyle = (s, transform) => {
       let clone = s.clone()
       clone.getText().setText('')
-      clone.setGeometry(f.getGeometry().getGeometries()[1]); // Radius
-      s.setGeometry(f.getGeometry().getGeometries()[0]); // Circle
-      return [ s, clone ]
+      let geometries = f.getGeometry().getGeometries()
+      let radius = geometries.find(g => g.getType() === 'LineString')
+      let circle = geometries.find(g => g.getType() === 'Circle')
+      s.setGeometry(radius);
+      clone.setGeometry(transform ? fromCircle(circle, 64) : circle);
+      return [ clone, s ]
     }
 
     // once interaction is deactivated, one cannot access to its tooltip,
@@ -144,7 +148,7 @@ const exports = function($scope, $q, $http, $compile, gettext,
     if (f.get('text')) {
       style.getText().setText(f.get('text'))
       if (geomType === 'GeometryCollection') {
-        return getCollectionStyle(style)
+        return getCollectionStyle(style, true)
       }
       return style
     }
@@ -165,7 +169,7 @@ const exports = function($scope, $q, $http, $compile, gettext,
 
   let style_ = new olStyleStyle({
     fill: new olStyleFill({
-      color: 'rgba(255, 204, 51, 0.3)'
+      color: 'rgba(255, 204, 51, 0.2)'
     }),
     stroke: new olStyleStroke({
       color: 'rgba(255, 204, 51, 1)',

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/MeasureController.js
@@ -242,7 +242,10 @@ const exports = function($scope, $q, $http, $compile, gettext,
       'Double-click or click last point to finish');
   const layer = new olLayerVector({
     source: new olSourceVector(),
-    style: style
+    style: style,
+    metadata: {
+      hidden: true
+    }
   })
   this.map_.addLayer(layer)
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/measure.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/measure/measure.html
@@ -16,4 +16,7 @@
        ng-model="ctrl.measureProfile.active" ng-show="!ctrl.measureProfile.active">Profile</a>
       <app-profile app-profile-data="ctrl.profileData" app-profile-interaction="ctrl.measureProfile" app-profile-map="::ctrl.map"></app-profile>
   </li>
+  <li ng-show="!ctrl.measureProfile.active">
+      <a href translate ng-click="ctrl.removeFeatures()">Reset</a>
+  </li>
 </ul>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
@@ -73,8 +73,7 @@ app-map {
     white-space: nowrap;
   }
   .ngeo-tooltip-measure {
-    opacity: 1;
-    font-weight: bold;
+    display: none;
   }
   .ngeo-tooltip-static {
     background-color: #ffcc33;

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/navbars.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/navbars.less
@@ -209,7 +209,7 @@ header {
 
 .measure .toolbox-panel {
   /* 4 measure tools */
-  width: 4 + (4 * @icon-width);
+  width: 5 + (5 * @icon-width);
 }
 
 .share .toolbox-panel {

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -87,7 +87,7 @@
     "ls": "0.2.1",
     "mapbox-gl": "1.7.0",
     "moment": "2.22.1",
-    "ngeo": "https://api.github.com/repos/camptocamp/ngeo/tarball/81ab841",
+    "ngeo": "https://api.github.com/repos/camptocamp/ngeo/tarball/b178a9e7451a4b660c728fedcf015e9f9854cd50",
     "ol-cesium": "2.0.0",
     "openlayers": "https://api.github.com/repos/openlayers/openlayers/tarball/f284b95cb897b3ce1b49b985b58ebe1ca76be1fe",
     "phantomjs-polyfill-string-includes": "1.0.0",


### PR DESCRIPTION
Transition from HTML tooltips to ol styles.

The sketchStyle class ngeo methods to get measure, store it in feature property on `measureend`, & final style use it, because text in tooltip is not available anymore.
Feature is stored & readded to layer when active tool changes.

A `hidden` property is added to measure layer, which prevent it to be displayed in layer manager.

Needs [small ngeo tweak](https://github.com/camptocamp/ngeo/commit/b178a9e7451a4b660c728fedcf015e9f9854cd50).

(last minute check show me azimut isn't drawn in print… is `Circle` supported in MF print?)