### PR TITLE
[c2cnextprod] Add support for map rotation

### DIFF
--- a/config/print/print-apps/geoportailv3/a0_landscape.jrxml
+++ b/config/print/print-apps/geoportailv3/a0_landscape.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -133,6 +134,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="3180" y="80" width="40" height="40" uuid="f12a63cb-600e-4beb-90ec-cc0761f78728"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a0_portrait.jrxml
+++ b/config/print/print-apps/geoportailv3/a0_portrait.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -131,6 +132,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="2190" y="80" width="40" height="40" uuid="ad0b3354-cc49-4b7f-a95d-15732e17692b"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a1_landscape.jrxml
+++ b/config/print/print-apps/geoportailv3/a1_landscape.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -128,6 +129,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="2190" y="80" width="40" height="40" uuid="4858a75b-31c8-47de-83d8-388df0ca324c"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a1_portrait.jrxml
+++ b/config/print/print-apps/geoportailv3/a1_portrait.jrxml
@@ -13,6 +13,7 @@
 	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -130,6 +131,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="1500" y="70" width="40" height="40" uuid="b33de99e-ea57-4985-8350-92c3a0673048"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a2_landscape.jrxml
+++ b/config/print/print-apps/geoportailv3/a2_landscape.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -133,6 +134,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="1500" y="70" width="40" height="40" uuid="a5576139-6e3d-42c0-a298-38a0121ab125"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a2_portrait.jrxml
+++ b/config/print/print-apps/geoportailv3/a2_portrait.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -128,6 +129,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="1010" y="70" width="40" height="40" uuid="e17fc23e-8cc7-4d54-bbfd-121c73995fc5"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a3_landscape.jrxml
+++ b/config/print/print-apps/geoportailv3/a3_landscape.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -122,6 +123,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="1010" y="70" width="40" height="40" uuid="6c51d535-2fa9-48c8-92e7-bbcfca3b140f"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a3_portrait.jrxml
+++ b/config/print/print-apps/geoportailv3/a3_portrait.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -128,6 +129,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="660" y="70" width="40" height="40" uuid="f4eb5984-c568-48ce-9a77-21fbaade2280"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/a4_landscape.jrxml
+++ b/config/print/print-apps/geoportailv3/a4_landscape.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -51,6 +52,10 @@
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 				</reportElement>
 				<subreportExpression><![CDATA[$P{mapSubReport}]]></subreportExpression>
+			</subreport>
+			<subreport>
+				<reportElement x="670" y="60" width="40" height="40" uuid="0fae1157-6844-4e51-9e64-b0cf1fdfcc86"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
 			</subreport>
 			<subreport>
 				<reportElement x="427" y="463" width="230" height="40" uuid="fa145068-76a5-4834-98ed-ce65b1976b3d">

--- a/config/print/print-apps/geoportailv3/a4_portrait.jrxml
+++ b/config/print/print-apps/geoportailv3/a4_portrait.jrxml
@@ -11,6 +11,7 @@
 	<property name="com.jaspersoft.studio.unit.rightMargin" value="mm"/>
 	<parameter name="mapSubReport" class="java.lang.String"/>
 	<parameter name="scalebarSubReport" class="java.lang.String"/>
+	<parameter name="northArrowSubReport" class="java.lang.String"/>
 	<parameter name="disclaimer" class="java.lang.String"/>
 	<parameter name="dateText" class="java.lang.String"/>
 	<parameter name="scaleTitle" class="java.lang.String"/>
@@ -133,6 +134,10 @@
 				</textElement>
 				<textFieldExpression><![CDATA[$P{dateText}+(new SimpleDateFormat("dd/MM/yyyy HH:mm")).format(new java.util.Date())]]></textFieldExpression>
 			</textField>
+			<subreport>
+				<reportElement x="420" y="70" width="40" height="40" uuid="8a359794-4174-4dce-81e8-c2519764d559"/>
+				<subreportExpression><![CDATA[$P{northArrowSubReport}]]></subreportExpression>
+			</subreport>
 		</band>
 	</title>
 </jasperReport>

--- a/config/print/print-apps/geoportailv3/config.yaml.tmpl
+++ b/config/print/print-apps/geoportailv3/config.yaml.tmpl
@@ -44,6 +44,11 @@ templates:
       scalebar: !scalebar
         width: 150
         height: 30
+      northArrow: !northArrow
+        size: 50
+        default:
+          graphic: "file://NorthArrow_10.svg"
+          backgroundColor: "rgba(214, 214, 214, 0)"
     processors: &processors
       - !reportBuilder  # compile all reports in current directory
         directory: '.'
@@ -60,6 +65,7 @@ templates:
         inputMapper: {map: map}
         outputMapper: {mapSubReport: mapSubReport}
       - !createScalebar {}
+      - !createNorthArrow {}
   A4 landscape: !template
     pdfConfig: !pdfConfig
       title: "A4 Landscape by geoportail.lu"

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -186,6 +186,7 @@ import '../../less/geoportailv3.less';
 
 import DragRotate from 'ol/interaction/DragRotate';
 import { shiftKeyOnly, altShiftKeyOnly } from 'ol/events/condition';
+import Rotate from 'ol/control/Rotate';
 
 function getDefaultHillshadeStyling() {
   const gettext = t => t;
@@ -1248,7 +1249,8 @@ MainController.prototype.createMap_ = function() {
       // the zoom to extent control will be added later since it depends on ol3dm
       new olControlFullScreen({label: '\ue01c', labelActive: '\ue02c'}),
       new olControlAttribution({collapsible: false,
-        collapsed: false, className: 'geoportailv3-attribution'})
+        collapsed: false, className: 'geoportailv3-attribution'}),
+      new Rotate({})
     ],
     interactions: interactions.extend([rotate]),
     keyboardEventTarget: document,

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -184,6 +184,9 @@ import '../../less/geoportailv3.less';
  import '../mvtstyling/SimpleStyleController.js';
  /* eslint-enable no-unused-vars */
 
+import DragRotate from 'ol/interaction/DragRotate';
+import { shiftKeyOnly, altShiftKeyOnly } from 'ol/events/condition';
+
 function getDefaultHillshadeStyling() {
   const gettext = t => t;
   return [{
@@ -1233,6 +1236,11 @@ MainController.prototype.createMap_ = function() {
     pinchRotate: false,
     constrainResolution: true
   });
+  const rotate = new DragRotate({
+    condition: new URL(window.location).searchParams.has('shiftKeyRotate')
+      ? shiftKeyOnly
+      : altShiftKeyOnly
+  });
   var map = this['map'] = new appMap({
     logo: false,
     controls: [
@@ -1242,14 +1250,14 @@ MainController.prototype.createMap_ = function() {
       new olControlAttribution({collapsible: false,
         collapsed: false, className: 'geoportailv3-attribution'})
     ],
-    interactions: interactions,
+    interactions: interactions.extend([rotate]),
     keyboardEventTarget: document,
     loadTilesWhileInteracting: true,
     loadTilesWhileAnimating: true,
     view: new olView({
       maxZoom: 19,
       minZoom: 8,
-      enableRotation: false,
+      enableRotation: true,
       extent: this.maxExtent_
     })
   });

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1237,7 +1237,7 @@ MainController.prototype.createMap_ = function() {
     constrainResolution: true
   });
   const rotate = new DragRotate({
-    condition: new URL(window.location).searchParams.has('shiftKeyRotate')
+    condition: new URLSearchParams(document.location.search).has('shiftKeyRotate')
       ? shiftKeyOnly
       : altShiftKeyOnly
   });

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/catalog/CatalogController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/catalog/CatalogController.js
@@ -142,7 +142,7 @@ exports.prototype.setThemeZooms = function(tree) {
       minZoom: 8,
       extent: this.maxExtent_,
       center: currentView.getCenter(),
-      enableRotation: false,
+      enableRotation: true,
       zoom: currentView.getZoom()
     }));
   }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
@@ -100,6 +100,22 @@ app-map {
   .ngeo-tooltip-static:before {
     border-top-color: #ffcc33;
   }
+  .ol-rotate {
+    right: auto;
+    left: 8px;
+    top: 196px;
+    button {
+      border-radius: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+}
+@media (max-width: 768px) {
+  .ol-viewport .ol-rotate {
+    top: 96px;
+  }
 }
 
 .hidden-2d {


### PR DESCRIPTION
Alt + Shift modifiers by default. By passing a `shiftKeyRotate` query param, changes to Shift modifier only (to be tested on linux
systems).

Print templates have been updated to have north arrow:
![Screenshot from 2020-07-03 12-36-04](https://user-images.githubusercontent.com/21686/86461204-eadecc00-bd29-11ea-99c3-4275c43f5349.png)
