### PR TITLE
Serial is not initialized at launch if existing in local storage

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
@@ -192,25 +192,7 @@ exports.prototype.onLayerUpdate_ = function(layers) {
   var bgLabel = 'blank';
   if (bgLayer) {
     bgLabel = bgLayer.get('label');
-
-  // If there is a expert mvt style in the localstorage but no parameter in the url
-    const itemKey = 'remoteIdForStyle_' + bgLabel;
-    const stateMvtExpertStyle = this.stateManager_.getValueFromLocalStorage(itemKey);
-    if (stateMvtExpertStyle !== undefined && stateMvtExpertStyle !== null) {
-      this.ngeoLocation_.updateParams({
-        'serial': stateMvtExpertStyle
-      });
-    }
   }
-
-  // If there is a medium mvt style in the localstorage but no parameter in the url
-  const stateMvtMediumStyle = this.stateManager_.getValueFromLocalStorage('mediumStyling');
-  if (stateMvtMediumStyle !== undefined && stateMvtMediumStyle !== null) {
-    this.ngeoLocation_.updateParams({
-      'serial': stateMvtMediumStyle
-    });
-  }
-
   this.stateManager_.updateState({
     'layers': layerIds.join('-'),
     'opacities': opacities.join('-'),

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
@@ -192,7 +192,25 @@ exports.prototype.onLayerUpdate_ = function(layers) {
   var bgLabel = 'blank';
   if (bgLayer) {
     bgLabel = bgLayer.get('label');
+
+  // If there is a expert mvt style in the localstorage but no parameter in the url
+    const itemKey = 'remoteIdForStyle_' + bgLabel;
+    const stateMvtExpertStyle = this.stateManager_.getValueFromLocalStorage(itemKey);
+    if (stateMvtExpertStyle !== undefined && stateMvtExpertStyle !== null) {
+      this.ngeoLocation_.updateParams({
+        'serial': stateMvtExpertStyle
+      });
+    }
   }
+
+  // If there is a medium mvt style in the localstorage but no parameter in the url
+  const stateMvtMediumStyle = this.stateManager_.getValueFromLocalStorage('mediumStyling');
+  if (stateMvtMediumStyle !== undefined && stateMvtMediumStyle !== null) {
+    this.ngeoLocation_.updateParams({
+      'serial': stateMvtMediumStyle
+    });
+  }
+
   this.stateManager_.updateState({
     'layers': layerIds.join('-'),
     'opacities': opacities.join('-'),

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -351,7 +351,7 @@ const MainController = function(
   }
 
   this.debouncedSaveMediumStyle_ = ngeoDebounce(() => {
-    appMvtStylingService.saveMediumStyle(JSON.stringify(this.mediumStylingData));
+    appMvtStylingService.saveMediumStyle(JSON.stringify(this.mediumStylingData), this.map_);
   }, 2000, false);
   this.debouncedSaveBgStyle_ = ngeoDebounce(() => {
     const bgLayer = this.backgroundLayerMgr_.get(this.map);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
@@ -32,9 +32,10 @@ class MvtStylingService {
    * @param {String} deletevtstyleUrl URL to delete a provisionned style
    * @param {String} getvtstyleUrl URL to get a provisionned style
    * @param {ngeo.map.BackgroundLayerMgr} ngeoBackgroundLayerMgr Background layer
+   * @param {ngeo.statemanager.Location} ngeoLocation ngeo location service.
    * @ngInject
    */
-  constructor($http, appUserManager, uploadvtstyleUrl, deletevtstyleUrl, getvtstyleUrl, ngeoBackgroundLayerMgr) {
+  constructor($http, appUserManager, uploadvtstyleUrl, deletevtstyleUrl, getvtstyleUrl, ngeoBackgroundLayerMgr, ngeoLocation) {
     this.http_ = $http;
     this.appUserManager_ = appUserManager;
     this.isCustomStyle = false;
@@ -42,6 +43,7 @@ class MvtStylingService {
     this.deletevtstyleUrl_ = deletevtstyleUrl;
     this.getvtstyleUrl_ = getvtstyleUrl;
     this.backgroundLayerMgr_ = ngeoBackgroundLayerMgr;
+    this.ngeoLocation_ = ngeoLocation;
   }
 
   getBgStyle() {
@@ -49,7 +51,36 @@ class MvtStylingService {
     const itemKey = this.createRemoteItemKey_(label);
     let id = localStorage.getItem(itemKey);
     const xyz_custom = id ? this.createXYZCustom_(id) : undefined;
-    const serial = new URLSearchParams(window.location.search).get('serial');
+    let url = new URLSearchParams(window.location.search);
+
+
+    // If there is a medium mvt style in the localstorage, force parameter in the url
+    const stateMvtMediumStyle = this.getLS_('mediumStyling');
+    if (stateMvtMediumStyle) {
+
+        // Set the permalink visible in browser
+        this.ngeoLocation_.updateParams({
+            'serial': stateMvtMediumStyle
+        });
+
+        // Set the url object used in this method
+        url.set('serial', stateMvtMediumStyle);
+    }
+
+    // If there is a expert mvt style in the localstorage, force parameter in the url
+    const stateMvtExpertStyle = this.getLS_(itemKey);
+    if (stateMvtExpertStyle) {
+
+        // Set the permalink visible in browser
+         this.ngeoLocation_.updateParams({
+            'serial': stateMvtExpertStyle
+        });
+
+        // Set the url object used in this method
+        url.set('serial', stateMvtExpertStyle);
+    }
+
+    const serial = url.get('serial');
     const config = {
       label,
       defaultMapBoxStyle,

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
@@ -200,6 +200,10 @@ saveBgStyle(layer, isPublished) {
     this.isCustomStyle = true;
     this.saveLS_(LS_KEY_EXPERT, data);
     console.log('Expert style saved in local storage');
+
+    // Remove medium style as it is unactive
+    this.deleteLS_(LS_KEY_MEDIUM);
+
     if (isPublished) {
         promises.push(this.publishStyle(layer, data));
     }
@@ -232,7 +236,7 @@ getUrlVtStyle(layer) {
   return this.getvtstyleUrl_ + '?id=' + id;
 }
 
-saveMediumStyle(style) {
+saveMediumStyle(style, map) {
     const promises = [];
     this.isCustomStyle = true;
     if (this.appUserManager_.isAuthenticated()) {
@@ -241,6 +245,12 @@ saveMediumStyle(style) {
     }
     this.saveLS_(LS_KEY_MEDIUM, style);
     console.log('Medium style saved in local storage');
+
+    // Remove expert style as it is unactive
+    const bgLayer = this.backgroundLayerMgr_.get(map);
+    this.unpublishStyle(bgLayer);
+    this.deleteLS_(LS_KEY_EXPERT);
+
     return Promise.all(promises);
 }
 


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSLUX-374

I changed the local storage behavior if there is already a expert or medium style saved. Now only the one active is saved there, the other is removed if existing. That insures that we can get only one as we launch the app without the permalink complete and can fill it with accurate local storage data without having two styles conflicting. This actually removes unused data from local storage.