### PR TITLE
Fix style of admin page `predefined WMS`

### DIFF
--- a/geoportal/geoportailv3_geoportal/admin/view/lux_predefined_wms.py
+++ b/geoportal/geoportailv3_geoportal/admin/view/lux_predefined_wms.py
@@ -7,9 +7,17 @@ from c2cgeoform.schema import GeoFormSchemaNode
 from c2cgeoform.views.abstract_views import AbstractViews
 from c2cgeoform.views.abstract_views import ListField
 
-_list_field = partial(ListField, LuxPredefinedWms)
-
 base_schema = GeoFormSchemaNode(LuxPredefinedWms)
+
+
+# override standard class chosen by geoform to avoid clash with css style .label
+# class="label" becomes class="_lux_label"
+class ListFieldLux(ListField):
+    def id(self):
+        return '_lux_' + self._key
+
+
+_list_field = partial(ListFieldLux, LuxPredefinedWms)
 
 
 @view_defaults(match_param='table=lux_predefined_wms')


### PR DESCRIPTION
a bug has been observed since geoforms uses by default the name of the column for the CSS class. This results in a clash for the column 'label' of the table `lux_predefined_wms`

Before
![image](https://user-images.githubusercontent.com/61978301/94933684-04c7b080-04cb-11eb-860c-caaaeafd4a7c.png)

After
![image](https://user-images.githubusercontent.com/61978301/94933742-1ad57100-04cb-11eb-977b-dff413e952e7.png)
