### PR TITLE
Fix building color with serialized config loading

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -210,6 +210,7 @@ function getDefaultMediumStyling() {
   },{
     label: gettext('Buildings'),
     color: '#D6AA85',
+    opacity : '1',
     fillExtrusions: ['lu_building-3d_public','lu_building-3d'],
     fills: ['lu_building','lu_building_public'],
     lines: ["lu_bridge_railway","lu_railway","lu_tunnel_railway"],
@@ -236,8 +237,8 @@ function getDefaultMediumStyling() {
 function getSimpleStylings() {
   const gettext = t => t;
   return [
-// ['Roads primary','Roads secondary','Vegetation','Buildings','Water']
-// ['#bc1515', '#bcffdd','#bcffdd','#bc1133','#bc1133'],
+// ['Roads primary','Roads secondary','Vegetation','Buildings','Water', 'Background']
+// ['#bc1515', '#bcffdd','#bcffdd','#bc1133','#bc1133', '#f2f2f2'],
     {label: gettext('Light grey'), hillshade: false, colors: ['#ffffff', '#ffffff','#d6e0d7','#e1e1e1','#cccccc','#f2f2f2'], selected: false},
     {label: gettext('Dark grey'), hillshade: false, colors: ['#808080', '#808080','#494b4a','#505052','#232426','#454545'], selected: false},
     {label: gettext('Dark sand'), hillshade: false, colors: ['#9e9375', '#9e9375','#6b6249','#403928','#b8aa84','#1a1814'], selected: false},

--- a/geoportal/geoportailv3_geoportal/views/userconfig.py
+++ b/geoportal/geoportailv3_geoportal/views/userconfig.py
@@ -84,15 +84,15 @@ class Config(object):
         config = json.loads(self.request.params['config'])
         paint_conf_dict = {}
         layout_conf_dict = {}
-        color_keys = ['background', 'line', 'fill', 'fillExtrusion']
+        color_keys = ['background', 'line', 'fill', 'fill-extrusion']
         for conf in json.loads(config):
             if 'color' in conf:
                 color = conf['color']
                 if 'opacity' in conf:
                     opacity = conf['opacity']
                 for color_key in color_keys:
-                    if 'fillExtrusion' in color_key:
-                        prop = 'fill-extrusion'
+                    if 'fill-extrusion' in color_key:
+                        prop = 'fillExtrusions'
                     else:
                         prop = color_key + 's'
 


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSLUX-386

To test it, just load a simple style from permalink and see if the building has the same styling as the simple style applied from the editor interface.

Seems the python file had the key reverse between what is in the config, and what is in the json style file. Other than that, the fillExtrusions opacity was set to default (0.45) instead of 1. I had to add opacity to the building config, hopefully it does not seems there is other opacity values set somewhere for fills or lines elements, as it sets the same opacity for the full "building" config when parsed in the python.