### PR TITLE
Fix sourcing of gunicorn params

### DIFF
--- a/env.default
+++ b/env.default
@@ -30,7 +30,7 @@ QGIS_VERSION=3.10
 REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_DB=0
-GUNICORN_PARAMS=--bind=:8080 --worker-class=gthread --threads=10 --workers=1 --timeout=60 --max-requests=1000 --max-requests-jitter=100
+GUNICORN_PARAMS="--bind=:8080 --worker-class=gthread --threads=10 --workers=1 --timeout=60 --max-requests=1000 --max-requests-jitter=100"
 DEVSERVER_HOST=webpack_dev_server:8080
 C2C_REDIS_URL=redis://redis:6379/0
 PGOPTIONS=-c statement_timeout=30000


### PR DESCRIPTION
Sourcing of the resulting `.env` file (merge of env.default and env.project)  (`source .env`) was broken.