### PR TITLE
Be sure the old background is removed

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1176,7 +1176,7 @@ const MainController = function(
   $scope.$on('authenticated', () => {
     // If is to avoid 'undefined' error at page loading as the theme is not fully loaded yet
     const bgLayer = this.backgroundLayerMgr_.get(this.map);
-    if (bgLayer && bgLayer.getMapBoxMap()) {
+    if (bgLayer && bgLayer.getMapBoxMap) {
       this.appMvtStylingService.getBgStyle().then(configs => {
         const config = configs.find(config => config.label === bgLayer.get('label'));
         if (config) {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/backgroundselector/BackgroundselectorController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/backgroundselector/BackgroundselectorController.js
@@ -63,6 +63,10 @@ class Controller {
 
             if (previous) {
                 previous.setVisible(false);
+            } else {
+              this.bgLayers.forEach(function(layer) {
+                layer.setVisible(false);
+              });
             }
             current.setVisible(true);
             this.bgLayer = current;
@@ -74,7 +78,7 @@ class Controller {
             const piwik = /** @type {Piwik} */ (window['_paq']);
             piwik.push(['setDocumentTitle', 'BackgroundAdded/' + this.bgLayer.get('label')]);
             piwik.push(['trackPageView']);
-        });
+        }, this);
       };
 
     /**


### PR DESCRIPTION
Sometimes previous variable is not set. 
In this case, hide each background layer to avoid a conflict with the new background.