### PR TITLE
Make API doc work with v4

### DIFF
--- a/geoportal/jsapi/examples/iterate_layers_api.html
+++ b/geoportal/jsapi/examples/iterate_layers_api.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>API V3 layers list</title>
+        <title>API V4 layers list</title>
         <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.2.2/css/bootstrap.min.css" rel="stylesheet" media="screen">        
         <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
         <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.3/underscore-min.js"></script>
         <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.2.2/bootstrap.min.js"></script>
-    <script src="//apiv3.geoportail.lu/apiv3loader.js"  type="text/javascript"></script>
+    <script src="/apiv4loader.js"  type="text/javascript"></script>
     </head>
     <body>
     <script type="text/html" id='usageList'>
         <h2>Layers available through the GeoAPI</h2>
-        <a href="//apiv3.geoportail.lu/">Back to the API V3 documentation</a>
+        <a href="//apiv4.geoportail.lu/">Back to the API V4 documentation</a>
 
         <table class="table table-striped table-condensed">
                 <thead>
@@ -71,7 +71,7 @@
           var template = $("#usageList").html();
           var i18n;
           var layersJson;
-          var i18nPromise = this.i18nPromise = fetch("https://apiv3.geoportail.lu/static-ngeo/not_used/build/en.json").then(function(resp) {
+          var i18nPromise = this.i18nPromise = fetch("/static-ngeo/not_used/build/en.json").then(function(resp) {
               return resp.json();
           }).then(function(json) {
               i18n = json['en'];

--- a/geoportal/jsapi/examples/public_mymaps.html
+++ b/geoportal/jsapi/examples/public_mymaps.html
@@ -7,7 +7,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js" integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js" integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.0/underscore-min.js"></script>
-    <script src="/apiv3loader.js"  type="text/javascript"></script>
+    <script src="/apiv4loader.js"  type="text/javascript"></script>
     <script>
     function sanitizeFilename(name) {
       if (name === undefined) return "";
@@ -73,7 +73,7 @@
           <pre>
 &lt;html&gt;
   &lt;head&gt;
-    &lt;script src=&quot;//apiv3.geoportail.lu/apiv3loader.js&quot;  type=&quot;text/javascript&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;/apiv4loader.js&quot;  type=&quot;text/javascript&quot;&gt;&lt;/script&gt;
   &lt;/head&gt;
   &lt;body&gt;
     &lt;div id="map1"&gt;&lt;/div&gt;
@@ -100,7 +100,7 @@
   </div>
 
   <h2>List of public Mymaps available through the GeoAPI.</h2>
-  <div class="text-right"><a href="//apiv3.geoportail.lu/">Back to the API V3 documentation</a></div>
+  <div class="text-right"><a href="//apiv4.geoportail.lu/">Back to the API V3 documentation</a></div>
   <script type="text/html" id='usageList'>
     <div class="row">
       <div class="col-4" style="max-height: calc(100vh - 4em);overflow-y: auto;">

--- a/geoportal/jsapi/jsdoc/api/index.md
+++ b/geoportal/jsapi/jsdoc/api/index.md
@@ -7,11 +7,11 @@ Although the options for data processing are limited compared with “real” of
 
 For any assistance as well as for request access, please contact our support here : <support@geoportail.lu>
 
-To help the developers, some examples and use cases are available on our [demo page](/examples)
+To help the developers, some examples and use cases are available on our [demo page](./examples)
 
-A catalog of public layers is available on the [List of layers page](/examples/iterate_layers_api.html).
+A catalog of public layers is available on the [List of layers page](./examples/iterate_layers_api.html).
 
-A catalog of public mymaps is available on the [List of public Mymaps page.](/examples/public_mymaps.html).
+A catalog of public mymaps is available on the [List of public Mymaps page.](./examples/public_mymaps.html).
 
 The Geoportail.lu V4 API is built on top of the [OpenLayers API](https://openlayers.org/en/v6.9.0/apidoc/)
 The Geoportail.lu V4 offers classes, methods, and properties to ease the build of geographical applications using luxembourg data.
@@ -25,20 +25,29 @@ All the needed resources are loaded by including the following js script.
 
 The script automatically includes the Geoportail V4 libraries as well as the OpenLayers libraries. Thus there is no need to include it again.
 
-The core API object is a [lux.Map](lux.Map.html) that extends an OpenLayers [ol.Map](https://openlayers.org/en/v6.9.0/apidoc/module-ol_Map-Map.html). This is the main entry point to create a basic map.
+The core API object is a [lux.Map](module-map-Map.html) that extends an OpenLayers [ol.Map](https://openlayers.org/en/v6.9.0/apidoc/module-ol_Map-Map.html). This is the main entry point to create a basic map.
 
-The main properties of a [lux.Map](lux.Map.html) are:
+The main properties of a [lux.Map](module-map-Map.html) are:
  - *target* : The id or the html element where the map is displayed
  - *bgLayer* : The Id of the background layer.
  - *zoom* : The starting zoom level.
  - *position* : The central point of the map.
 
 Displaying a map is simple as shown by the following code:
-```js
+<pre><code>
 var map = new lux.Map({
   target: 'map1',
   bgLayer: 'basemap_2015_global',
   zoom: 18,
   position: [75977, 75099]
 });
-```
+</code></pre>
+<div id="map1" style="width:250px; height:250px;"></div>
+<script src="/apiv4loader.js"  type="text/javascript"></script>
+<script>
+var map = new lux.Map({
+  target: 'map1',
+  bgLayer: 'basemap_2015_global',
+  zoom: 18,
+  position: [75977, 75099]
+});</script>

--- a/geoportal/jsapi/src/map.js
+++ b/geoportal/jsapi/src/map.js
@@ -265,7 +265,7 @@ function findLayerByName_(name, layers) {
  * @export
  * @api
  */
-export default class Map extends OpenLayersMap {
+class Map extends OpenLayersMap {
 
   /**
    * @param {MapOptions} options Map options.
@@ -2770,3 +2770,4 @@ export default class Map extends OpenLayersMap {
     }
   }
 }
+export default Map;

--- a/geoportal/jsapi/src/mymap.js
+++ b/geoportal/jsapi/src/mymap.js
@@ -54,7 +54,7 @@ import d3Elevation from '@geoblocks/d3profile';
  *
  * @api
  */
-export default class MyMap {
+class MyMap {
 
   /**
    * @param {MyMapOptions} options Options.
@@ -1218,3 +1218,4 @@ export default class MyMap {
     return points.concat(lines, others);
   }
 }
+export default MyMap;


### PR DESCRIPTION
The PR makes various adaptions to in API doc to work with v4

- Fixes links on API doc home
- Should add example map on API doc home
- Includes `Map` and `MyMap` classes in doc
- Updates `public_mymaps.html` and `iterate_layers_api.hmtl` examples to use APIv4 (which will currently break the link to navigate back, as apiv4.geoportail.lu does not exist yet)