### PR TITLE
Fix MyMapsController by removing setDragHandler method

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/mymaps/MymapsController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/mymaps/MymapsController.js
@@ -361,7 +361,6 @@ const exports = function($scope, $compile, $sce,
       this.appMymaps_.getMaps(this.filterMapOwner, this.filterCategoryId).then(function(mymaps) {
         this.choosing = true;
         this.maps = mymaps;
-        this.setDragHandler();
       }.bind(this));
     }
   }.bind(this));
@@ -374,7 +373,6 @@ const exports = function($scope, $compile, $sce,
         this.choosing = true;
         this.maps = mymaps;
         this.filterMapOwner = null;
-        this.setDragHandler();
       }.bind(this));
     }
   }.bind(this));
@@ -527,7 +525,6 @@ exports.prototype.modalShownHidden = function(value) {
     this.modal = undefined;
     return false;
   } else if (this.modal !== undefined) {
-    this.setDragHandler();
     return true;
   }
 };
@@ -830,7 +827,6 @@ exports.prototype.closeMap = function() {
  * @export
  */
 exports.prototype.openConfirmDelete = function() {
-  this.setDragHandler();
   this.confirmDelete = true;
 };
 
@@ -840,7 +836,6 @@ exports.prototype.openConfirmDelete = function() {
  * @export
  */
 exports.prototype.openConfirmDeleteObjects = function() {
-  this.setDragHandler();
   this.confirmDeleteObjects = true;
 };
 
@@ -864,7 +859,6 @@ exports.prototype.openConfirmDeleteAMap = function(mapId, mapTitle) {
   this.requestedMapIdToDelete = mapId;
   this.requestedMapTitle = mapTitle;
   this.choosing = false;
-  this.setDragHandler();
 };
 
 /**
@@ -1146,7 +1140,6 @@ exports.prototype.openChooseMapModal = function() {
           } else if (mymaps.length !== 0 || this.appUserManager_.getMymapsAdmin()) {
             this.choosing = true;
             this.maps = mymaps;
-            this.setDragHandler();
           } else {
             this.notify_(this.gettextCatalog.getString(
                 'You have no existing Maps, please create a New Map'
@@ -1191,7 +1184,6 @@ exports.prototype.openMergeLinesModal = function() {
     var msg = this.gettextCatalog.getString('Il faut au moins 2 lignes disponibles pour pouvoir les fusionner.');
     this.notify_(msg, appNotifyNotificationType.INFO);
   }
-  this.setDragHandler();
 };
 
 
@@ -1210,7 +1202,6 @@ exports.prototype.openModifyMapModal = function() {
     this.newIsPublic = this.appMymaps_.mapIsPublic;
     this.modal = 'MODIFY';
   }
-  this.setDragHandler();
 };
 
 
@@ -1275,7 +1266,6 @@ exports.prototype.deleteAMap = function(mapId) {
         this.askToConnect();
       } else {
         this.choosing = true;
-        this.setDragHandler();
         this.requestedMapTitle = undefined;
         this.requestedMapIdToDelete = undefined;
         if (!this.ngeoOfflineMode.isEnabled()) {
@@ -1686,15 +1676,6 @@ exports.prototype.fit = function(extent) {
  */
 exports.prototype.afterReorder = function(feature, array) {
   this.drawnFeatures_.computeOrder();
-};
-
-
-/**
- * Set the drag handle on element H4.
- * @export
- */
-exports.prototype.setDragHandler = function() {
-  $('.modal-dialog').draggable('option', 'handle', 'h4');
 };
 
 appModule.controller('AppMymapsController', exports);


### PR DESCRIPTION
PR removes `setDragHandler` from `MyMapsController`, which currently causes an error and does not seem to be necessary when testing and looking at: https://github.com/Geoportail-Luxembourg/geoportailv3/blob/integration/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/message/modalComponent.js#L126