### PR TITLE
Offline UI

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -195,6 +195,7 @@ import '../../less/geoportailv3.less';
 
 import '../lux-iframe-preview/lux-iframe-preview.ts';
 import '../gmf-lidar-panel/gmf-lidar-panel.ts';
+import '../offlineWebComponent.ts';
 
 import DragRotate from 'ol/interaction/DragRotate';
 import {platformModifierKeyOnly} from 'ol/events/condition';

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -129,6 +129,7 @@ import '../../less/geoportailv3.less';
  import appQueryCasiporeportController from '../query/CasiporeportController.js';
  import appQueryPdsreportDirective from '../query/pdsreportDirective.js';
  import appQueryPdsreportController from '../query/PdsreportController.js';
+ import appOfflineBar from '../offline/offlinebar.js'
 
  //const appQueryQueryStyles = goog.require('app.query.QueryStyles');
  import appQueryQueryDirective from '../query/queryDirective.js';
@@ -387,8 +388,8 @@ const MainController = function(
     ngeoLocation, appExport, appGetDevice,
     appOverviewMapShow, showCruesLink, showAnfLink, appOverviewMapBaseLayer, appNotify, $window,
   appSelectedFeatures, $locale, appRouting, $document, cesiumURL, ipv6Substitution,
-    $rootScope, ngeoOlcsService, tiles3dLayers, tiles3dUrl, ngeoNetworkStatus, ngeoOfflineMode,
-    ageLayerIds, showAgeLink, appGetLayerForCatalogNode,
+    $rootScope, ngeoOlcsService, tiles3dLayers, tiles3dUrl, ngeoNetworkStatus,
+    appOfflineBar, ngeoOfflineMode, ageLayerIds, showAgeLink, appGetLayerForCatalogNode,
     showCruesRoles, ageCruesLayerIds, appOfflineDownloader, appOfflineRestorer, appMymapsOffline,
     ngeoDownload, appMvtStylingService, ngeoDebounce, geonetworkBaseUrl, appBlankLayer) {
   /**
@@ -707,6 +708,12 @@ const MainController = function(
    * @private
    */
   this.networkStatus_ = ngeoNetworkStatus;
+
+  /**
+  * @type {ngeo.offline.Mode}
+  * @export
+  */
+  this.offlineBar = appOfflineBar;
 
   /**
    * @type {ngeo.offline.Mode}

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -167,6 +167,7 @@ import '../../less/geoportailv3.less';
  import appMymaps from '../Mymaps.js';
 
  import appMymapsOffline from '../MymapsOffline.js';
+ import appToggleOffline from '../offline/toggleOffline.js';
  import appOlcsToggle3d from '../olcs/toggle3d.js';
  import appOlcsExtent from '../olcs/Extent.js';
  import appProjections from '../projections.js';

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -375,6 +375,7 @@
         </div>
         <div ng-if="mainCtrl.selectedLayers.length>0" class="slider-layer-label"><i class="fa fa-arrow-left"></i> <span>{{mainCtrl.selectedLayers[0].get('label') | translate}}</span></div>
       </div>
+      <lux-offline></lux-offline>
       <ngeo-offline
           ng-if="mainCtrl.offlineBar.isBarOpen()"
           ngeo-offline-map="::mainCtrl.map"

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -381,12 +381,13 @@
           ng-prop-disabled="mainCtrl.offlineBar.isNgeoOfflineActive()"
       ></lux-offline>
       <ngeo-offline
-          ng-if="mainCtrl.offlineBar.isBarOpen()"
+          ng-class="mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide'"
           ng-click="mainCtrl.offlineBar.toggleNgeoOffline()"
           ngeo-offline-map="::mainCtrl.map"
           ngeo-offline-mask-margin="::100"
           ngeo-offline-min-zoom="::12"
           ngeo-offline-max-zoom="::16"
+          ngeo-full-offline-active="mainCtrl.offlineBar.isFullOfflineActive()"
           ng-class="{'offline-mode': mainCtrl.offlineMode.isEnabled()}"
           ng-show="!mainCtrl.embedded"
       >

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -364,7 +364,7 @@
       </div>
     <div class="map-wrapper">
       <app-askredirect app-askredirect-show="mainCtrl.showRedirect"></app-askredirect>
-      <app-map app-map-map="::mainCtrl.map"></app-map>
+      <app-map app-map-map="::mainCtrl.map" app-map-offline-mode="::mainCtrl.offlineMode"></app-map>
       <ngeo-olcs-controls3d ng-if="mainCtrl.is3dEnabled()" ol3dm="::mainCtrl.ol3dm"></ngeo-olcs-controls3d>
       <div ng-show="mainCtrl.activeLayersComparator" app-slider app-slider-map="::mainCtrl.map" app-slider-active="mainCtrl.activeLayersComparator"
            app-slider-layers="::mainCtrl.selectedLayers" class="slider-line-area ng-hide" ng-cloak>
@@ -375,7 +375,7 @@
         </div>
         <div ng-if="mainCtrl.selectedLayers.length>0" class="slider-layer-label"><i class="fa fa-arrow-left"></i> <span>{{mainCtrl.selectedLayers[0].get('label') | translate}}</span></div>
       </div>
-      <ngeo-offline
+      <!-- <ngeo-offline
           ngeo-offline-map="::mainCtrl.map"
           ngeo-offline-mask-margin="::100"
           ngeo-offline-min-zoom="::12"
@@ -383,7 +383,7 @@
           ng-class="{'offline-mode': mainCtrl.offlineMode.isEnabled()}"
           ng-show="!mainCtrl.embedded"
       >
-      </ngeo-offline>
+      </ngeo-offline> -->
       <app-backgroundselector
         ng-if="!mainCtrl.ol3dm_.isMeshEnabled()"
         class="background-layer"

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -364,7 +364,7 @@
       </div>
     <div class="map-wrapper">
       <app-askredirect app-askredirect-show="mainCtrl.showRedirect"></app-askredirect>
-      <app-map app-map-map="::mainCtrl.map" app-map-offline-mode="::mainCtrl.offlineMode"></app-map>
+      <app-map app-map-map="::mainCtrl.map"></app-map>
       <ngeo-olcs-controls3d ng-if="mainCtrl.is3dEnabled()" ol3dm="::mainCtrl.ol3dm"></ngeo-olcs-controls3d>
       <div ng-show="mainCtrl.activeLayersComparator" app-slider app-slider-map="::mainCtrl.map" app-slider-active="mainCtrl.activeLayersComparator"
            app-slider-layers="::mainCtrl.selectedLayers" class="slider-line-area ng-hide" ng-cloak>
@@ -375,7 +375,8 @@
         </div>
         <div ng-if="mainCtrl.selectedLayers.length>0" class="slider-layer-label"><i class="fa fa-arrow-left"></i> <span>{{mainCtrl.selectedLayers[0].get('label') | translate}}</span></div>
       </div>
-      <!-- <ngeo-offline
+      <ngeo-offline
+          ng-if="mainCtrl.offlineBar.isBarOpen()"
           ngeo-offline-map="::mainCtrl.map"
           ngeo-offline-mask-margin="::100"
           ngeo-offline-min-zoom="::12"
@@ -383,7 +384,7 @@
           ng-class="{'offline-mode': mainCtrl.offlineMode.isEnabled()}"
           ng-show="!mainCtrl.embedded"
       >
-      </ngeo-offline> -->
+      </ngeo-offline>
       <app-backgroundselector
         ng-if="!mainCtrl.ol3dm_.isMeshEnabled()"
         class="background-layer"

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -375,8 +375,8 @@
         </div>
         <div ng-if="mainCtrl.selectedLayers.length>0" class="slider-layer-label"><i class="fa fa-arrow-left"></i> <span>{{mainCtrl.selectedLayers[0].get('label') | translate}}</span></div>
       </div>
-      <lux-offline 
-          ng-if="mainCtrl.offlineBar.isBarOpen()"
+      <lux-offline
+          ng-class="mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide'"
           ng-click="mainCtrl.offlineBar.toggleFullOffline()"
           ng-prop-disabled="mainCtrl.offlineBar.isNgeoOfflineActive()"
       ></lux-offline>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -375,9 +375,14 @@
         </div>
         <div ng-if="mainCtrl.selectedLayers.length>0" class="slider-layer-label"><i class="fa fa-arrow-left"></i> <span>{{mainCtrl.selectedLayers[0].get('label') | translate}}</span></div>
       </div>
-      <lux-offline></lux-offline>
+      <lux-offline 
+          ng-if="mainCtrl.offlineBar.isBarOpen()"
+          ng-click="mainCtrl.offlineBar.toggleFullOffline()"
+          ng-prop-disabled="mainCtrl.offlineBar.isNgeoOfflineActive()"
+      ></lux-offline>
       <ngeo-offline
           ng-if="mainCtrl.offlineBar.isBarOpen()"
+          ng-click="mainCtrl.offlineBar.toggleNgeoOffline()"
           ngeo-offline-map="::mainCtrl.map"
           ngeo-offline-mask-margin="::100"
           ngeo-offline-min-zoom="::12"

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/map/map.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/map/map.html
@@ -1,4 +1,5 @@
 <div ngeo-map="ctrl.map" class="app-map">
+  <app-toggle-offline app-offlinebar-map="::ctrl.map" app-offlinebar-offline-mode="::ctrl.offlineMode"></app-toggle-offline>
   <app-toggle-3d></app-toggle-3d>
   <app-infobar app-infobar-map="::ctrl.map"></app-infobar>
 </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/map/map.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/map/map.html
@@ -1,5 +1,5 @@
 <div ngeo-map="ctrl.map" class="app-map">
-  <app-toggle-offline app-offlinebar-map="::ctrl.map" app-offlinebar-offline-mode="::ctrl.offlineMode"></app-toggle-offline>
+  <app-toggle-offline></app-toggle-offline>
   <app-toggle-3d></app-toggle-3d>
   <app-infobar app-infobar-map="::ctrl.map"></app-infobar>
 </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/map/mapDirective.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/map/mapDirective.js
@@ -19,7 +19,8 @@ import appModule from '../module.js';
 const exports = function(appMapTemplateUrl) {
   return {
     scope: {
-      'map': '=appMapMap'
+      'map': '=appMapMap',
+      'offlineMode': '=appMapOfflineMode'
     },
     bindToController: true,
     controller: 'AppMapController',

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/map/mapDirective.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/map/mapDirective.js
@@ -19,8 +19,7 @@ import appModule from '../module.js';
 const exports = function(appMapTemplateUrl) {
   return {
     scope: {
-      'map': '=appMapMap',
-      'offlineMode': '=appMapOfflineMode'
+      'map': '=appMapMap'
     },
     bindToController: true,
     controller: 'AppMapController',

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/module.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/module.js
@@ -135,6 +135,7 @@ exports.constant('appLayerinfoTemplateUrl', 'templatecache/appLayerinfoTemplateU
 exports.constant('appAuthenticationTemplateUrl', 'templatecache/appAuthenticationTemplateUrl');
 exports.constant('appInfobarTemplateUrl', 'templatecache/appInfobarTemplateUrl');
 exports.constant('app3dbarTemplateUrl', 'templatecache/app3dbarTemplateUrl');
+exports.constant('appOfflineBarTemplateUrl', 'templatecache/appOfflineBarTemplateUrl');
 exports.constant('appProjectionselectorTemplateUrl', 'templatecache/appProjectionselectorTemplateUrl');
 exports.constant('appMapTemplateUrl', 'templatecache/appMapTemplateUrl');
 exports.constant('appThemeswitcherTemplateUrl', 'templatecache/appThemeswitcherTemplateUrl');
@@ -167,6 +168,7 @@ function templateRunner($templateCache) {
   $templateCache.put('templatecache/ngeoLayertreeTemplateUrl', require('./catalog/layertree.html'));
   $templateCache.put('templatecache/ngeoPopupTemplateUrl', require('./layerinfo/popup.html'));
   $templateCache.put('templatecache/ngeoScaleselectorTemplateUrl', require('./infobar/scaleselector.html'));
+  $templateCache.put('templatecache/appOfflineBarTemplateUrl', require('./offline/offlinebar.html'));
   $templateCache.put('templatecache/ngeoOfflineTemplateUrl', require('./offlineNgeoComponent.html')); //  # FIXME was a function
   $templateCache.put('templatecache/ngeoOlcsControls3dTemplateUrl', require('./olcs/controls3d.html'));
   $templateCache.put('templatecache/appBackgroundselectorTemplateUrl', require('./backgroundselector/backgroundselector.html'));

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
@@ -22,7 +22,7 @@ function getDefaultMapBoxStyleUrl(label) {
     const searchParams = new URLSearchParams(document.location.search);
     const server = searchParams.get('embeddedserver');
     const proto = searchParams.get('embeddedserverprotocol') || 'http';
-    const url = (server ? `${proto}://${server}` : 'https://vectortiles.geoportail.lu') + `/styles/${label}/style.json`;
+    const url = (server ? `${proto}://${server}/static` : 'https://vectortiles.geoportail.lu') + `/styles/${label}/style.json`;
     return url;
 }
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
@@ -1,6 +1,7 @@
 <div class="ol-control ol-toggleOffline-bar">
   <div class="ol-unselectable ol-control">
-    <button type="button" ng-click="ctrl.toggleBar()">Off</button>
+    <button type="button" ng-click="ctrl.toggleBar()">
+      <i class="fa fa-download" aria-hidden="true"></i>
+    </button>
   </div>
-  <!-- the offline buttons of this bar (ngeo offline and offline web component are part of main.html and moved here via css -->
 </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
@@ -2,8 +2,5 @@
   <div class="ol-unselectable ol-control">
     <button type="button" ng-click="ctrl.toggleBar()">Off</button>
   </div>
-  <div ng-if="ctrl.isBarOpen() == true" class="ol-unselectable ol-control ol-toggleFullOffline">
-    <button type="button" ng-click="">Lux</button>
-  </div>
-  <!--ngeo offline component is part of main.html and moved here via css -->
+  <!-- the offline buttons of this bar (ngeo offline and offline web component are part of main.html and moved here via css -->
 </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
@@ -1,0 +1,20 @@
+<div class="ol-control ol-toggleOffline-bar">
+  <div class="ol-unselectable ol-control" ng-class="{'ol-control-on' : (ctrl.isOpened && (ctrl.fullOfflineActive || ctrl.selectOfflineActive))}">
+    <button type="button" ng-click="ctrl.toggleSelector()">Off</button>
+  </div>
+  <div ng-if="ctrl.isOpened == true" class="ol-unselectable ol-control ol-toggleFullOffline"
+     ng-class="{'ol-control-on' : ctrl.fullOfflineActive}">
+  <button type="button" ng-click="ctrl.toggleFullOffline()">Lux</button>
+  </div>
+  <div ng-if="ctrl.isOpened == true" class="ol-unselectable ol-control ol-toggleSelectOffline"
+     ng-class="{'ol-control-on' : ctrl.selectOfflineActive}" ng-click="ctrl.toggleSelectOffline()">
+      <ngeo-offline
+        ngeo-offline-map="ctrl.map"
+        ngeo-offline-mask-margin="::100"
+        ngeo-offline-min-zoom="::12"
+        ngeo-offline-max-zoom="::16"
+        ng-class="{'offline-mode': ctrl.offlineMode.isEnabled()}"
+      >
+      </ngeo-offline>
+  </div>
+</div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.html
@@ -1,20 +1,9 @@
 <div class="ol-control ol-toggleOffline-bar">
-  <div class="ol-unselectable ol-control" ng-class="{'ol-control-on' : (ctrl.isOpened && (ctrl.fullOfflineActive || ctrl.selectOfflineActive))}">
-    <button type="button" ng-click="ctrl.toggleSelector()">Off</button>
+  <div class="ol-unselectable ol-control">
+    <button type="button" ng-click="ctrl.toggleBar()">Off</button>
   </div>
-  <div ng-if="ctrl.isOpened == true" class="ol-unselectable ol-control ol-toggleFullOffline"
-     ng-class="{'ol-control-on' : ctrl.fullOfflineActive}">
-  <button type="button" ng-click="ctrl.toggleFullOffline()">Lux</button>
+  <div ng-if="ctrl.isBarOpen() == true" class="ol-unselectable ol-control ol-toggleFullOffline">
+    <button type="button" ng-click="">Lux</button>
   </div>
-  <div ng-if="ctrl.isOpened == true" class="ol-unselectable ol-control ol-toggleSelectOffline"
-     ng-class="{'ol-control-on' : ctrl.selectOfflineActive}" ng-click="ctrl.toggleSelectOffline()">
-      <ngeo-offline
-        ngeo-offline-map="ctrl.map"
-        ngeo-offline-mask-margin="::100"
-        ngeo-offline-min-zoom="::12"
-        ngeo-offline-max-zoom="::16"
-        ng-class="{'offline-mode': ctrl.offlineMode.isEnabled()}"
-      >
-      </ngeo-offline>
-  </div>
+  <!--ngeo offline component is part of main.html and moved here via css -->
 </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.js
@@ -7,16 +7,31 @@
 
   constructor() {
     this.barOpen_ = false;
+    this.ngeoOffline_ = false;
+    this.fullOffline_ = false;
   }
 
   isBarOpen() {
     return this.barOpen_;
+  }
+  isNgeoOfflineActive() {
+    return this.ngeoOffline_;
+  }
+  isFullOfflineActive() {
+    return this.fullOffline_;
   }
 
   toggleBar() {
     this.barOpen_ = !this.barOpen_;
   }
 
+  toggleNgeoOffline() {
+    this.ngeoOffline_ = !this.ngeoOffline_;
+  }
+
+  toggleFullOffline() {
+    this.fullOffline_ = !this.fullOffline_;
+  }
 };
 
 /**

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.js
@@ -1,0 +1,27 @@
+/**
+ * @module app.offline.Bar
+ */
+ import appModule from '../module.js';
+
+ const exports = class {
+
+  constructor() {
+    this.barOpen_ = false;
+  }
+
+  isBarOpen() {
+    return this.barOpen_;
+  }
+
+  toggleBar() {
+    this.barOpen_ = !this.barOpen_;
+  }
+
+};
+
+/**
+ * @type {!angular.Module}
+ */
+ appModule.service('appOfflineBar', exports);
+
+export default exports;

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/toggleOffline.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/toggleOffline.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview This file provides the "app-toggle-offline" component.
+ *
+ * Example:
+ *
+ * <app-toggle-offline><app-toggle-offline>
+ */
+ import appModule from '../module.js';
+
+ class Controller {
+ 
+   constructor() {
+     /**
+      * @type {boolean}
+      */
+     this.isOpened = false;
+      /**
+      * @type {boolean}
+      */
+      this.fullOfflineActive = false;
+      /**
+      * @type {boolean}
+      */
+      this.selectOfflineActive = false;
+   }
+   /**
+    * @export
+    */
+   toggleSelector() {
+     this.isOpened = !this.isOpened;
+     if (!this.isOpened) {
+      this.fullOfflineActive = false;
+      this.selectOfflineActive = false;
+     }
+   }
+ 
+   toggleFullOffline() {
+      this.fullOfflineActive = !this.fullOfflineActive;
+   }
+   toggleSelectOffline() {
+      this.selectOfflineActive = !this.selectOfflineActive;
+   }
+ }
+ 
+ 
+ /**
+  * @ngInject
+  * @param {string} appOfflineBarTemplateUrl The template url.
+  * @return {angular.Directive} The Directive Object Definition.
+  */
+ const exports = function(appOfflineBarTemplateUrl) {
+   return {
+     restrict: 'E',
+     scope: {
+      'map': '=appOfflinebarMap',
+      'offlineMode': '=appOfflinebarOfflineMode'
+    },
+     controller: Controller,
+     controllerAs: 'ctrl',
+     bindToController: true,
+     templateUrl: appOfflineBarTemplateUrl
+   };
+ };
+ 
+ appModule.directive('appToggleOffline', exports);
+ 
+ 
+ export default exports;
+ 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/toggleOffline.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/toggleOffline.js
@@ -9,37 +9,23 @@
 
  class Controller {
  
-   constructor() {
-     /**
-      * @type {boolean}
-      */
-     this.isOpened = false;
-      /**
-      * @type {boolean}
-      */
-      this.fullOfflineActive = false;
-      /**
-      * @type {boolean}
-      */
-      this.selectOfflineActive = false;
-   }
+    /**
+   * @ngInject
+   * @param {app.offline.Bar} appOfflineBar The service.
+   */
+  constructor(appOfflineBar) {
+    this.offlineBar = appOfflineBar;
+ }
    /**
     * @export
     */
-   toggleSelector() {
-     this.isOpened = !this.isOpened;
-     if (!this.isOpened) {
-      this.fullOfflineActive = false;
-      this.selectOfflineActive = false;
-     }
+   toggleBar() {
+     this.offlineBar.toggleBar();
    }
- 
-   toggleFullOffline() {
-      this.fullOfflineActive = !this.fullOfflineActive;
-   }
-   toggleSelectOffline() {
-      this.selectOfflineActive = !this.selectOfflineActive;
-   }
+
+   isBarOpen() {
+    return this.offlineBar.isBarOpen();
+  }
  }
  
  
@@ -51,10 +37,7 @@
  const exports = function(appOfflineBarTemplateUrl) {
    return {
      restrict: 'E',
-     scope: {
-      'map': '=appOfflinebarMap',
-      'offlineMode': '=appOfflinebarOfflineMode'
-    },
+     scope: {},
      controller: Controller,
      controllerAs: 'ctrl',
      bindToController: true,

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineNgeoComponent.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineNgeoComponent.html
@@ -1,6 +1,6 @@
 <div class="main-button">
   <span ng-if="!$ctrl.hasData()">
-    <div class="no-data" ng-click="$ctrl.toggleViewExtentSelection()"></div>
+    <button class="no-data" ng-click="$ctrl.toggleViewExtentSelection()" ng-disabled="$ctrl.fullOfflineActive"></button>
   </span>
   <span ng-if="$ctrl.hasData()">
     <div class="with-data" ng-click="$ctrl.showMenu()"></div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -99,23 +99,23 @@ export class LuxOffline extends LuxBaseElement {
         }
       }
       if (this.tilePackages.IN_PROGRESS.length > 0) {
-        this.status = 'IN_PROGRESS'
+        this.status = 'IN_PROGRESS';
       } else if (this.tilePackages.UPDATE_AVAILABLE.length > 0) {
-        this.status = 'UPDATE_AVAILABLE'
+        this.status = 'UPDATE_AVAILABLE';
       } else {
-        this.status = 'UP_TO_DATE'
+        this.status = 'UP_TO_DATE';
       }
     }
 
     updateTiles() {
       this.tilePackages.UPDATE_AVAILABLE.forEach(tilePackage => {
-        this.sendRequest(tilePackage, 'PUT')
+        this.sendRequest(tilePackage, 'PUT');
       })
     }
 
     deleteTiles() {
       this.tilePackages.ALL.forEach(tilePackage => {
-        this.sendRequest(tilePackage, 'DELETE')
+        this.sendRequest(tilePackage, 'DELETE');
       })
   }
 
@@ -125,7 +125,7 @@ export class LuxOffline extends LuxBaseElement {
         .then((data) => {
           console.log('Success:', data);
           if (method === 'PUT') {
-            this.checkTilesByInterval()
+            this.checkTilesByInterval();
           }
         })
         .catch((error) => {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -12,6 +12,9 @@ import {styleMap} from 'lit/directives/style-map.js';
 @customElement('lux-offline')
 export class LuxOffline extends LuxBaseElement {
 
+    @property({type: Boolean})
+    disabled: boolean = false;
+
     @state()
     private menuDisplayed;
 
@@ -44,75 +47,73 @@ export class LuxOffline extends LuxBaseElement {
 
     renderMenu() {
         return html`
-<div class="offline-btns">
-<div class="offline-btn btn btn-primary" @click="${this.checkTiles}">
-  check background offline data
-</div>
-<br>
-<div class="offline-btn btn btn-primary" @click="${this.showInfo}">
-  show offline data info
-</div>
-<br>
-${this.constructor.offlinePackages.map((definition) =>
-    this.renderOfflinePackageItem(definition.title, definition.packageName))}
-</div>
-`;
+          <div class="offline-btns">
+            <div class="offline-btn btn btn-primary" @click="${this.checkTiles}">
+              check background offline data
+            </div>
+            <br>
+            <div class="offline-btn btn btn-primary" @click="${this.showInfo}">
+              show offline data info
+            </div>
+            <br>
+            ${this.constructor.offlinePackages.map((definition) =>
+              this.renderOfflinePackageItem(definition.title, definition.packageName))}
+          </div>
+          `;
     }
 
     renderOfflinePackageItem(title, packageName) {
         return html`
-<div class="offline-btn btn btn-primary" id="PUT-${packageName}" @click="${this.alterTiles}">
-  update ${title}
-</div>
-<div class="offline-btn btn btn-primary" id="DELETE-${packageName}" @click="${this.alterTiles}">
-  delete ${title}
-</div>
-<br>
-`;
+          <div class="offline-btn btn btn-primary" id="PUT-${packageName}" @click="${this.alterTiles}">
+            update ${title}
+          </div>
+          <div class="offline-btn btn btn-primary" id="DELETE-${packageName}" @click="${this.alterTiles}">
+            delete ${title}
+          </div>
+          <br>
+          `;
     }
 
     renderInfo() {
         return html`
-            <div class="modal" tabindex="-1" role="dialog">
-              <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title">${i18next.t('Offline package info')}</h4>
+          <div class="modal" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                  <h4 class="modal-title">${i18next.t('Offline package info')}</h4>
+                </div>
+                <div class="modal-body">
+                  <div>
+                    <p><pre ng-style="{'font-size':'8px'}"> ${this.statusDict} </pre></p>
                   </div>
-                  <div class="modal-body">
-    <div>
-      <p><pre ng-style="{'font-size':'8px'}"> ${this.statusDict} </pre></p>
-  </div>
-  </div>
-  </div>
-  </div>
-  </div>    
-`;
+                </div>
+              </div>
+            </div>
+          </div>
+              `;
     }
 
     render() {
         return html`
-<div class="db-button">
-  <span>
-    <div class="no-data webcomponent" @click="${this.toggleMenu}"></div>
-  </span>
-</div>
-${this.menuDisplayed?this.renderMenu():""}
-${this.renderInfo()}
+          <div class="db-button">
+            <span>
+              <button ?disabled="${this.disabled}" class="no-data offline-wc" @click="${this.toggleMenu}"></button>
+            </span>
+          </div>
+        ${this.menuDisplayed?this.renderMenu():""}
+        ${this.renderInfo()}
         `;
     }
 
-    checkTiles()
-    {
+    checkTiles() {
         console.log("check");
         let checkPromise = fetch(this.baseURL + "/check");
         checkPromise.then(response => response.text()).then(text => this.statusDict = text);
         this.showInfo()
     }
 
-    showInfo()
-    {
+    showInfo() {
         $(this.modal).modal('show');
     }
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -77,6 +77,9 @@ export class LuxOffline extends LuxBaseElement {
       fetch(this.baseURL + "/check")
         .then((response) => response.json())
         .then((statusJson) => this.getStatus(statusJson))
+        .catch((error) => {
+          console.error('Error:', error);
+        });
     }
 
     getStatus(tiles) {
@@ -111,6 +114,9 @@ export class LuxOffline extends LuxBaseElement {
       this.tilePackages.UPDATE_AVAILABLE.forEach(tilePackage => {
         this.sendRequest(tilePackage, 'PUT');
       })
+      if (this.tilePackages.UPDATE_AVAILABLE.length > 0) {
+        this.checkTilesByInterval();
+      }
     }
 
     deleteTiles() {
@@ -123,9 +129,6 @@ export class LuxOffline extends LuxBaseElement {
       fetch(this.baseURL + "/map/" + tiles, {method})
         .then((data) => {
           console.log('Success:', data);
-          if (method === 'PUT') {
-            this.checkTilesByInterval();
-          }
         })
         .catch((error) => {
           console.error('Error:', error);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -26,6 +26,8 @@ export class LuxOffline extends LuxBaseElement {
     @state()
     private status;
 
+    private checkTimeout;
+
     constructor() {
         super();
         const searchParams = new URLSearchParams(document.location.search);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -113,7 +113,7 @@ export class LuxOffline extends LuxBaseElement {
         this.status = 'UP_TO_DATE';
       }
       if (this.status == 'IN_PROGRESS') {
-        this.reCheckTilesTimeout();
+        this.reCheckTilesTimeout(2500);
       }
     }
 
@@ -124,7 +124,8 @@ export class LuxOffline extends LuxBaseElement {
     }
 
     deleteTiles() {
-      this.tilePackages.ALL.forEach(tilePackage => {
+      // keep resources, so that vector maps remain operational
+      this.tilePackages.ALL.filter(tp => tp != 'resources').forEach(tilePackage => {
         this.sendRequest(tilePackage, 'DELETE');
       })
   }
@@ -133,21 +134,21 @@ export class LuxOffline extends LuxBaseElement {
       fetch(this.baseURL + "/map/" + tiles, {method})
         .then((data) => {
           console.log('Success:', data);
-          this.checkTiles();
         })
         .catch((error) => {
           console.error('Error:', error);
-        });
+        })
+        .finally(() => {this.reCheckTilesTimeout(250)});
     }
 
-    reCheckTilesTimeout() {
+    reCheckTilesTimeout(timeout) {
       // prevent multiple timers
       if (this.checkTimeout !== undefined) {
         clearTimeout(this.checkTimeout);
       }
       this.checkTimeout = setTimeout(()=> {
         this.checkTiles();
-      }, 3000)
+      }, timeout)
     }
 
     createRenderRoot() {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -26,6 +26,10 @@ export class LuxOffline extends LuxBaseElement {
 
     constructor() {
         super();
+        const searchParams = new URLSearchParams(document.location.search);
+        const server = searchParams.get('embeddedserver');
+        const proto = searchParams.get('embeddedserverprotocol') || 'http';
+        this.baseURL = (server ? `${proto}://${server}` : "http://localhost:8766/map/")
     }
 
     static offlinePackages = [
@@ -102,7 +106,7 @@ ${this.renderInfo()}
     checkTiles()
     {
         console.log("check");
-        let checkPromise = fetch("http://localhost:8766/check");
+        let checkPromise = fetch(this.baseURL + "/check");
         checkPromise.then(response => response.text()).then(text => this.statusDict = text);
         this.showInfo()
     }
@@ -118,7 +122,7 @@ ${this.renderInfo()}
         let method = eventId.substring(0, separatorPos);
         let packageName = eventId.substring(separatorPos+1);
         console.log(method + " " + packageName);
-        let alterPromise = fetch("http://localhost:8766/map/" + packageName, {method})
+        let alterPromise = fetch(this.baseURL + "/map/" + packageName, {method})
         alterPromise.then(res => res.text());
     }
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -121,7 +121,6 @@ export class LuxOffline extends LuxBaseElement {
 
     sendRequest(tiles: string, method: string) {
       fetch(this.baseURL + "/map/" + tiles, {method})
-        .then((response) => response.json())
         .then((data) => {
           console.log('Success:', data);
           if (method === 'PUT') {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -1,13 +1,7 @@
-import 'jquery';
-import 'bootstrap/js/modal.js';
-
 import i18next from 'i18next';
-
 import {LuxBaseElement} from './LuxBaseElement';
 import {html} from 'lit';
-import {customElement, state, query, property} from 'lit/decorators.js';
-import {styleMap} from 'lit/directives/style-map.js';
-
+import {customElement, state, property} from 'lit/decorators.js';
 
 @customElement('lux-offline')
 export class LuxOffline extends LuxBaseElement {
@@ -19,13 +13,15 @@ export class LuxOffline extends LuxBaseElement {
     private menuDisplayed;
 
     @state()
-    private infoDisplayed;
+    private tilePackages = {
+      ALL: [],
+      IN_PROGRESS: [],
+      UPDATE_AVAILABLE: [],
+      UP_TO_DATE: []
+    };
 
     @state()
-    private statusDict;
-
-    @query('.modal')
-    private modal: HTMLElement;
+    private status;
 
     constructor() {
         super();
@@ -33,102 +29,114 @@ export class LuxOffline extends LuxBaseElement {
         const server = searchParams.get('embeddedserver');
         const proto = searchParams.get('embeddedserverprotocol') || 'http';
         this.baseURL = (server ? `${proto}://${server}` : "http://localhost:8766/map/")
+        if (server) {
+          this.checkTiles()
+        } else {
+          this.disabled = true;
+        }
     }
-
-    static offlinePackages = [
-        {title: 'roadmap', packageName: 'omt-geoportail-lu'},
-        {title: 'topomap', packageName: 'omt-topo-geoportail-lu'},
-        {title: 'contours', packageName: 'contours-lu'},
-        {title: 'hillshade', packageName: 'hillshade-lu'},
-        {title: 'resources', packageName: 'resources'},
-        {title: 'fonts', packageName: 'fonts'},
-        {title: 'sprites', packageName: 'sprites'}
-    ]
 
     renderMenu() {
         return html`
           <div class="offline-btns">
-            <div class="offline-btn btn btn-primary" @click="${this.checkTiles}">
-              check background offline data
+            <div class="offline-btn btn btn-primary" @click="${this.updateTiles}" ?disabled="${this.status!=="UPDATE_AVAILABLE"}">
+            ${i18next.t('Update offline data')}
+            ${this.status==="IN_PROGRESS"
+              ? html `<i class="fa fa-circle-o-notch fa-spin"></i>`
+              : ''
+            }
             </div>
             <br>
-            <div class="offline-btn btn btn-primary" @click="${this.showInfo}">
-              show offline data info
+            <div class="offline-btn btn btn-primary" @click="${this.deleteTiles}" ?disabled="${this.status==="IN_PROGRESS"}">
+              ${i18next.t('Delete offline data')}
             </div>
             <br>
-            ${this.constructor.offlinePackages.map((definition) =>
-              this.renderOfflinePackageItem(definition.title, definition.packageName))}
           </div>
           `;
-    }
-
-    renderOfflinePackageItem(title, packageName) {
-        return html`
-          <div class="offline-btn btn btn-primary" id="PUT-${packageName}" @click="${this.alterTiles}">
-            update ${title}
-          </div>
-          <div class="offline-btn btn btn-primary" id="DELETE-${packageName}" @click="${this.alterTiles}">
-            delete ${title}
-          </div>
-          <br>
-          `;
-    }
-
-    renderInfo() {
-        return html`
-          <div class="modal" tabindex="-1" role="dialog">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                  <h4 class="modal-title">${i18next.t('Offline package info')}</h4>
-                </div>
-                <div class="modal-body">
-                  <div>
-                    <p><pre ng-style="{'font-size':'8px'}"> ${this.statusDict} </pre></p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-              `;
     }
 
     render() {
         return html`
           <div class="db-button">
             <span>
-              <button ?disabled="${this.disabled}" class="no-data offline-wc" @click="${this.toggleMenu}"></button>
+              <button ?disabled="${this.disabled}" class="no-data offline-wc" @click="${this.toggleMenu}"
+                title="${i18next.t('Full offline (only available on mobile)')}"></button>
             </span>
           </div>
         ${this.menuDisplayed?this.renderMenu():""}
-        ${this.renderInfo()}
         `;
     }
 
-    checkTiles() {
-        console.log("check");
-        let checkPromise = fetch(this.baseURL + "/check");
-        checkPromise.then(response => response.text()).then(text => this.statusDict = text);
-        this.showInfo()
-    }
-
-    showInfo() {
-        $(this.modal).modal('show');
-    }
-
-    alterTiles(e) {
-        let eventId = e.target.id;
-        let separatorPos = eventId.indexOf('-');
-        let method = eventId.substring(0, separatorPos);
-        let packageName = eventId.substring(separatorPos+1);
-        console.log(method + " " + packageName);
-        let alterPromise = fetch(this.baseURL + "/map/" + packageName, {method})
-        alterPromise.then(res => res.text());
-    }
-
     toggleMenu() {
-        this.menuDisplayed = !this.menuDisplayed;
+      this.menuDisplayed = !this.menuDisplayed;
+    }
+
+    checkTiles() {
+      fetch(this.baseURL + "/check")
+        .then((response) => response.json())
+        .then((statusJson) => this.getStatus(statusJson))
+    }
+
+    getStatus(tiles) {
+      this.tilePackages = {
+        ALL: [],
+        IN_PROGRESS: [],
+        UPDATE_AVAILABLE: [],
+        UP_TO_DATE: []
+      }
+      for(const tileKey in tiles) {
+        this.tilePackages.ALL.push(tileKey);
+        if (tiles[tileKey].status === "IN_PROGRESS") {
+          this.tilePackages.IN_PROGRESS.push(tileKey);
+        } else if (tiles[tileKey].current < tiles[tileKey].available) {
+          this.tilePackages.UPDATE_AVAILABLE.push(tileKey);
+        } else {
+          this.tilePackages.UP_TO_DATE.push(tileKey);
+        }
+      }
+      if (this.tilePackages.IN_PROGRESS.length > 0) {
+        this.status = 'IN_PROGRESS'
+      } else if (this.tilePackages.UPDATE_AVAILABLE.length > 0) {
+        this.status = 'UPDATE_AVAILABLE'
+      } else {
+        this.status = 'UP_TO_DATE'
+      }
+    }
+
+    updateTiles() {
+      this.tilePackages.UPDATE_AVAILABLE.forEach(tilePackage => {
+        this.sendRequest(tilePackage, 'PUT')
+      })
+    }
+
+    deleteTiles() {
+      this.tilePackages.ALL.forEach(tilePackage => {
+        this.sendRequest(tilePackage, 'DELETE')
+      })
+  }
+
+    sendRequest(tiles: string, method: string) {
+      fetch(this.baseURL + "/map/" + tiles, {method})
+        .then((response) => response.json())
+        .then((data) => {
+          console.log('Success:', data);
+          if (method === 'PUT') {
+            this.checkTilesByInterval()
+          }
+        })
+        .catch((error) => {
+          console.error('Error:', error);
+        });
+    }
+
+    checkTilesByInterval() {
+      this.status = 'IN_PROGRESS'
+      const checkInterval = setInterval(()=> {
+        this.checkTiles();
+        if (this.status !== 'IN_PROGRESS') {
+          clearInterval(checkInterval);
+        }
+      }, 500)
     }
 
     createRenderRoot() {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -1,0 +1,133 @@
+import 'jquery';
+import 'bootstrap/js/modal.js';
+
+import i18next from 'i18next';
+
+import {LuxBaseElement} from './LuxBaseElement';
+import {html} from 'lit';
+import {customElement, state, query, property} from 'lit/decorators.js';
+import {styleMap} from 'lit/directives/style-map.js';
+
+
+@customElement('lux-offline')
+export class LuxOffline extends LuxBaseElement {
+
+    @state()
+    private menuDisplayed;
+
+    @state()
+    private infoDisplayed;
+
+    @state()
+    private statusDict;
+
+    @query('.modal')
+    private modal: HTMLElement;
+
+    constructor() {
+        super();
+    }
+
+    static offlinePackages = [
+        {title: 'roadmap', packageName: 'omt-geoportail-lu'},
+        {title: 'topomap', packageName: 'omt-topo-geoportail-lu'},
+        {title: 'contours', packageName: 'contours-lu'},
+        {title: 'hillshade', packageName: 'hillshade-lu'},
+        {title: 'resources', packageName: 'resources'},
+        {title: 'fonts', packageName: 'fonts'},
+        {title: 'sprites', packageName: 'sprites'}
+    ]
+
+    renderMenu() {
+        return html`
+<div class="offline-btns">
+<div class="offline-btn btn btn-primary" @click="${this.checkTiles}">
+  check background offline data
+</div>
+<br>
+<div class="offline-btn btn btn-primary" @click="${this.showInfo}">
+  show offline data info
+</div>
+<br>
+${this.constructor.offlinePackages.map((definition) =>
+    this.renderOfflinePackageItem(definition.title, definition.packageName))}
+</div>
+`;
+    }
+
+    renderOfflinePackageItem(title, packageName) {
+        return html`
+<div class="offline-btn btn btn-primary" id="PUT-${packageName}" @click="${this.alterTiles}">
+  update ${title}
+</div>
+<div class="offline-btn btn btn-primary" id="DELETE-${packageName}" @click="${this.alterTiles}">
+  delete ${title}
+</div>
+<br>
+`;
+    }
+
+    renderInfo() {
+        return html`
+            <div class="modal" tabindex="-1" role="dialog">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">${i18next.t('Offline package info')}</h4>
+                  </div>
+                  <div class="modal-body">
+    <div>
+      <p><pre ng-style="{'font-size':'8px'}"> ${this.statusDict} </pre></p>
+  </div>
+  </div>
+  </div>
+  </div>
+  </div>    
+`;
+    }
+
+    render() {
+        return html`
+<div class="db-button">
+  <span>
+    <div class="no-data webcomponent" @click="${this.toggleMenu}"></div>
+  </span>
+</div>
+${this.menuDisplayed?this.renderMenu():""}
+${this.renderInfo()}
+        `;
+    }
+
+    checkTiles()
+    {
+        console.log("check");
+        let checkPromise = fetch("http://localhost:8766/check");
+        checkPromise.then(response => response.text()).then(text => this.statusDict = text);
+        this.showInfo()
+    }
+
+    showInfo()
+    {
+        $(this.modal).modal('show');
+    }
+
+    alterTiles(e) {
+        let eventId = e.target.id;
+        let separatorPos = eventId.indexOf('-');
+        let method = eventId.substring(0, separatorPos);
+        let packageName = eventId.substring(separatorPos+1);
+        console.log(method + " " + packageName);
+        let alterPromise = fetch("http://localhost:8766/map/" + packageName, {method})
+        alterPromise.then(res => res.text());
+    }
+
+    toggleMenu() {
+        this.menuDisplayed = !this.menuDisplayed;
+    }
+
+    createRenderRoot() {
+        // no shadow dom
+        return this;
+    }
+}

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -90,7 +90,9 @@ export class LuxOffline extends LuxBaseElement {
         this.tilePackages.ALL.push(tileKey);
         if (tiles[tileKey].status === "IN_PROGRESS") {
           this.tilePackages.IN_PROGRESS.push(tileKey);
-        } else if (tiles[tileKey].current < tiles[tileKey].available) {
+        } else if ((tiles[tileKey].current < tiles[tileKey].available) 
+          || (!tiles[tileKey].current && tiles[tileKey].available)
+          ) {
           this.tilePackages.UPDATE_AVAILABLE.push(tileKey);
         } else {
           this.tilePackages.UP_TO_DATE.push(tileKey);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineWebComponent.ts
@@ -10,6 +10,9 @@ export class LuxOffline extends LuxBaseElement {
     disabled: boolean = false;
 
     @state()
+    private server;
+
+    @state()
     private menuDisplayed;
 
     @state()
@@ -28,12 +31,11 @@ export class LuxOffline extends LuxBaseElement {
         const searchParams = new URLSearchParams(document.location.search);
         const server = searchParams.get('embeddedserver');
         const proto = searchParams.get('embeddedserverprotocol') || 'http';
-        this.baseURL = (server ? `${proto}://${server}` : "http://localhost:8766/map/")
+        this.baseURL = (server ? `${proto}://${server}` : "http://localhost:8766/map/");
         if (server) {
-          this.checkTiles()
-        } else {
-          this.disabled = true;
+          this.checkTiles();
         }
+        this.server = server;
     }
 
     renderMenu() {
@@ -59,7 +61,7 @@ export class LuxOffline extends LuxBaseElement {
         return html`
           <div class="db-button">
             <span>
-              <button ?disabled="${this.disabled}" class="no-data offline-wc" @click="${this.toggleMenu}"
+              <button ?disabled="${this.disabled || !this.server}" class="no-data offline-wc" @click="${this.toggleMenu}"
                 title="${i18next.t('Full offline (only available on mobile)')}"></button>
             </span>
           </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
@@ -149,6 +149,7 @@ footer,
 
 body.embedded {
   app-backgroundselector,
+  app-toggle-offline,
   app-toggle-3d,
   app-infobar,
   .location-button,

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/layout.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/layout.less
@@ -337,26 +337,6 @@ app-map > div {
   }
 }
 
-.ol-toggleSelectOffline {
-  right: 48px;
-  padding: 0;
-  bottom: -41px;
-  z-index: 2;
-  button {
-    font-family: 'DINNextLTPro-Condensed', Arial, sans-serif !important;
-    line-height: 1.8em;
-  }
-  //move ngeo offline buttons to expected position
-  .main-button {
-    position: inherit;
-    margin-bottom: -1px;
-    margin-right: -1px;
-  }
-  .validate-extent {
-    position: fixed;
-    top: 90px;
-  }
-}
 .ol-toggleOffline-bar {
   right: 50px;
   padding: 0;

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/layout.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/layout.less
@@ -326,6 +326,48 @@ app-map > div {
   }
 }
 
+.ol-toggleFullOffline {
+  right: 3px;
+  padding: 0;
+  bottom: -41px;
+  z-index: 2;
+  button {
+    font-family: 'DINNextLTPro-Condensed', Arial, sans-serif !important;
+    line-height: 1.8em;
+  }
+}
+
+.ol-toggleSelectOffline {
+  right: 48px;
+  padding: 0;
+  bottom: -41px;
+  z-index: 2;
+  button {
+    font-family: 'DINNextLTPro-Condensed', Arial, sans-serif !important;
+    line-height: 1.8em;
+  }
+  //move ngeo offline buttons to expected position
+  .main-button {
+    position: inherit;
+    margin-bottom: -1px;
+    margin-right: -1px;
+  }
+  .validate-extent {
+    position: fixed;
+    top: 90px;
+  }
+}
+.ol-toggleOffline-bar {
+  right: 50px;
+  padding: 0;
+  bottom: 194px;
+  z-index: 2;
+  button {
+    font-family: 'DINNextLTPro-Condensed', Arial, sans-serif !important;
+    line-height: 1.8em;
+  }
+}
+
 .location-button {
   z-index: 2;
   bottom: 55px;

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -45,14 +45,19 @@ ngeo-offline, lux-offline {
 
   .offline-btns {
     position: absolute;
-    top: 2.2rem;
-    left: calc(~"50% - 10rem");
+    top: 40%;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
     text-align: center;
   }
 
   .offline-btn {
       // width: 20rem;
       margin: 5px;
+      i {
+        margin-left: 6px;
+      }
   }
 
   .validate-extent {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -29,6 +29,10 @@ ngeo-offline, lux-offline {
         content: @fa-var-database;
       }
     }
+    .offline-wc[disabled] {
+      opacity: 0.65;
+      cursor: not-allowed;
+    }
     .with-data {
       color: red;
     }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -68,6 +68,11 @@ ngeo-offline {
   }
 }
 
+//FIXME: just for testing purposes
+.modal-backdrop {
+  z-index: -1;
+}
+
 .offline-msg {
   display: none;
 }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -4,8 +4,8 @@ ngeo-offline {
   }
   .main-button {
     position: absolute;
-    right: 8px;
-    bottom: 15rem;
+    right: 96px;
+    bottom: 152px;
     cursor: pointer;
     .no-data {
       color: black;
@@ -68,11 +68,6 @@ ngeo-offline {
   }
 }
 
-//FIXME: just for testing purposes
-.modal-backdrop {
-  z-index: -1;
-}
-
 .offline-msg {
   display: none;
 }
@@ -92,10 +87,6 @@ ngeo-offline {
       height: 40px;
       line-height: 40px;
     }
-  }
-
-  .main-button {
-    bottom: 104px;
   }
 }
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -1,8 +1,8 @@
-ngeo-offline {
+ngeo-offline, lux-offline {
   div {
     z-index: 1;
   }
-  .main-button {
+  .main-button, .db-button {
     position: absolute;
     right: 96px;
     bottom: 152px;
@@ -24,10 +24,16 @@ ngeo-offline {
         content: @fa-var-arrow-circle-o-down;
       }
     }
+    .webcomponent {
+      &::after {
+        content: @fa-var-database;
+      }
+    }
     .with-data {
       color: red;
     }
   }
+  .db-button {bottom: 198px}
 
   &.offline-mode {
     .main-button {
@@ -37,9 +43,21 @@ ngeo-offline {
     }
   }
 
+  .offline-btns {
+    position: absolute;
+    top: 2.2rem;
+    left: calc(~"50% - 10rem");
+    text-align: center;
+  }
+
+  .offline-btn {
+      // width: 20rem;
+      margin: 5px;
+  }
+
   .validate-extent {
     position: absolute;
-    top: 4.5rem;
+    bottom: 4.5rem;
     width: 12rem;
     left: calc(~"50% - 6rem");
   }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -29,7 +29,7 @@ ngeo-offline, lux-offline {
         content: @fa-var-database;
       }
     }
-    .offline-wc[disabled] {
+    .no-data[disabled], .with-data[disabled], .offline-wc[disabled] {
       opacity: 0.65;
       cursor: not-allowed;
     }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -24,7 +24,7 @@ ngeo-offline, lux-offline {
         content: @fa-var-arrow-circle-o-down;
       }
     }
-    .webcomponent {
+    .offline-wc {
       &::after {
         content: @fa-var-database;
       }
@@ -33,7 +33,7 @@ ngeo-offline, lux-offline {
       color: red;
     }
   }
-  .db-button {bottom: 198px}
+  .db-button {right: 52px}
 
   &.offline-mode {
     .main-button {
@@ -57,7 +57,7 @@ ngeo-offline, lux-offline {
 
   .validate-extent {
     position: absolute;
-    bottom: 4.5rem;
+    top: 4.5rem;
     width: 12rem;
     left: calc(~"50% - 6rem");
   }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.de.json
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.de.json
@@ -1,8 +1,11 @@
 {
   "Copy": "",
   "custom": "",
+  "Delete offline data": "Offline Daten herunterladen",
   "Embed map": "",
+  "Full offline (only available on mobile)": "Full offline (nur mobile App)",
   "large": "",
   "medium": "",
-  "small": ""
+  "small": "",
+  "Update offline data": "Offline Daten löschen"
 }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.en.json
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.en.json
@@ -1,8 +1,11 @@
 {
   "Copy": "",
   "custom": "",
+  "Delete offline data": "",
   "Embed map": "",
+  "Full offline (only available on mobile)": "",
   "large": "",
   "medium": "",
-  "small": ""
+  "small": "",
+  "Update offline data": ""
 }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.fr.json
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.fr.json
@@ -1,8 +1,11 @@
 {
   "Copy": "Copier",
   "custom": "Taille personnalisée",
+  "Delete offline data": "Supprimer données hors connexion",
   "Embed map": "Intégrer la carte",
+  "Full offline (only available on mobile)": "Full offline (seulement mobile)",
   "large": "Grande",
   "medium": "Moyenne",
-  "small": "Petite"
+  "small": "Petite",
+  "Update offline data": "Mettre à jour données hors connexion"
 }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.lb.json
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/locales/app.lb.json
@@ -1,8 +1,11 @@
 {
   "Copy": "",
   "custom": "",
+  "Delete offline data": "",
   "Embed map": "",
+  "Full offline (only available on mobile)": "",
   "large": "",
   "medium": "",
-  "small": ""
+  "small": "",
+  "Update offline data": ""
 }

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/component.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/component.js
@@ -75,6 +75,7 @@ exports.component_ = {
     'maskMargin': '<?ngeoOfflineMaskMargin',
     'minZoom': '<?ngeoOfflineMinZoom',
     'maxZoom': '<?ngeoOfflineMaxZoom',
+    'fullOfflineActive': '<?ngeoFullOfflineActive',
   },
   controller: 'ngeoOfflineController',
   templateUrl: ngeoOfflineTemplateUrl
@@ -241,6 +242,13 @@ exports.Controller = class {
      * @export
      */
     this.maxZoom;
+
+    /**
+     * Indicates if full offline tool is active (to disable ngeoOffline).
+     * @type {boolean}
+     * @export
+     */
+    this.fullOfflineActive;
 
     /**
      * Map view max zoom constraint.


### PR DESCRIPTION
The PR adds an offline toggle button (`offlinebar`) that opens toggle buttons for the existing ngeoOffline component and an offline web component to serve as a UI for the new "full offline" mode:

Todos:
- [x] disable ngeoOffline button if web component is active
- [x] disable full offline on desktop (not working yet because web component button is rendered twice)
- [x] refine UI in web component
- [x] adapt icons