### PR TITLE
fix search results in IOS

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
@@ -951,6 +951,7 @@ exports.selected_ =
       } else if (dataset === 'cms') {
         this.$window_.open('https://www.geoportail.lu' + suggestion.url, '_blank');
       }
+      this.$window_.document.activeElement.blur()
     };
 
 /**

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/search.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/search.less
@@ -62,6 +62,8 @@ span.twitter-typeahead {
     -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
     background-clip: padding-box;
+    overflow: auto;
+    max-height: 90vh;
   }
   .tt-suggestion {
     display: block;


### PR DESCRIPTION
on small screens with a big number of results, items far down cannot be reached

the results list is therefore made scrollable (auto)

however in IOS, the viewport is not reduced by the keyboard overlay, so the whole screen may become scrollable
this seems to be a hard to fix undesirable feature of IOS
 => https://selleo.com/til/posts/l8xyxi1sao-preventing-body-scroll-for-modals-in-ios
 => https://stackoverflow.com/questions/37713970/ios-css-js-overlay-scroll-but-prevent-body-scroll