### PR TITLE
Offline: Fix buttons disabled status

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -380,17 +380,16 @@
       <lux-offline-reload></lux-offline-reload>
       <lux-offline
           ng-class="mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide'"
-          ng-click="mainCtrl.offlineBar.toggleFullOffline()"
           ng-prop-disabled="mainCtrl.offlineBar.isNgeoOfflineActive()"
+          ng-prop-bar="mainCtrl.offlineBar"
       ></lux-offline>
       <ngeo-offline
           ng-class="mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide'"
-          ng-click="mainCtrl.offlineBar.toggleNgeoOffline()"
           ngeo-offline-map="::mainCtrl.map"
           ngeo-offline-mask-margin="::100"
           ngeo-offline-min-zoom="::12"
           ngeo-offline-max-zoom="::16"
-          ngeo-full-offline-active="mainCtrl.offlineBar.isFullOfflineActive()"
+          ngeo-full-offline-active="mainCtrl.offlineBar.fullOffline_"
           ng-class="{'offline-mode': mainCtrl.offlineMode.isEnabled()}"
           ng-show="!mainCtrl.embedded"
       >

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -382,6 +382,7 @@
           ng-class="mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide'"
           ng-prop-disabled="mainCtrl.offlineBar.isNgeoOfflineActive()"
           ng-prop-bar="mainCtrl.offlineBar"
+          ng-prop-scope="mainCtrl.scope_"
       ></lux-offline>
       <ngeo-offline
           ng-class="mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide'"

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/lux-offline/lux-offline.component.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/lux-offline/lux-offline.component.ts
@@ -11,6 +11,9 @@ export class LuxOffline extends LuxBaseElement {
     @property({type: Boolean})
     disabled: boolean = false;
 
+    @property()
+    private bar;
+
     @state()
     private menuDisplayed;
 
@@ -78,6 +81,7 @@ export class LuxOffline extends LuxBaseElement {
 
     toggleMenu() {
       this.menuDisplayed = !this.menuDisplayed;
+      this.bar.toggleFullOffline();
     }
 
     createRenderRoot() {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/lux-offline/lux-offline.component.ts
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/lux-offline/lux-offline.component.ts
@@ -14,6 +14,9 @@ export class LuxOffline extends LuxBaseElement {
     @property()
     private bar;
 
+    @property()
+    private scope;
+
     @state()
     private menuDisplayed;
 
@@ -82,6 +85,7 @@ export class LuxOffline extends LuxBaseElement {
     toggleMenu() {
       this.menuDisplayed = !this.menuDisplayed;
       this.bar.toggleFullOffline();
+      this.scope.$digest()
     }
 
     createRenderRoot() {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offline/offlinebar.js
@@ -26,11 +26,15 @@
   }
 
   toggleNgeoOffline() {
-    this.ngeoOffline_ = !this.ngeoOffline_;
+    if (!this.isFullOfflineActive()) {
+      this.ngeoOffline_ = !this.ngeoOffline_;
+    }
   }
 
   toggleFullOffline() {
-    this.fullOffline_ = !this.fullOffline_;
+    if (!this.isNgeoOfflineActive()) {
+      this.fullOffline_ = !this.fullOffline_;
+    }
   }
 };
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/component.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/component.js
@@ -102,7 +102,7 @@ exports.Controller = class {
    * @ngdoc controller
    * @ngname ngeoOfflineController
    */
-  constructor($timeout, ngeoFeatureOverlayMgr, ngeoOfflineServiceManager, ngeoOfflineConfiguration, ngeoOfflineMode, ngeoNetworkStatus) {
+  constructor($timeout, ngeoFeatureOverlayMgr, ngeoOfflineServiceManager, ngeoOfflineConfiguration, ngeoOfflineMode, ngeoNetworkStatus, appOfflineBar) {
 
     /**
      * @type {angular.$timeout}
@@ -132,6 +132,8 @@ exports.Controller = class {
      * @export
      */
     this.offlineMode = ngeoOfflineMode;
+
+    this.offlineBar = appOfflineBar;
 
     /**
      * @type {ngeo.offline.NetworkStatus}
@@ -329,6 +331,7 @@ exports.Controller = class {
   toggleViewExtentSelection(finished) {
     this.menuDisplayed = false;
     this.selectingExtent = !this.selectingExtent;
+    this.offlineBar.toggleNgeoOffline();
 
     this.map.removeLayer(this.maskLayer_);
     this.removeZoomConstraints_();


### PR DESCRIPTION
PR only toggles one offline mode if the other one is inactive.

Note: This is necessary since `ng-click` seems to be triggered even though button is `disabled`.