### PR TITLE
Ngeo offline: Display button correctly

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -385,13 +385,15 @@
           ng-prop-scope="mainCtrl.scope_"
       ></lux-offline>
       <ngeo-offline
-          ng-class="mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide'"
+          ng-class="[
+                      mainCtrl.offlineBar.isBarOpen() ? 'show' : 'hide', 
+                      {'offline-mode': mainCtrl.offlineMode.isEnabled()}
+                    ]"
           ngeo-offline-map="::mainCtrl.map"
           ngeo-offline-mask-margin="::100"
           ngeo-offline-min-zoom="::12"
           ngeo-offline-max-zoom="::16"
           ngeo-full-offline-active="mainCtrl.offlineBar.fullOffline_"
-          ng-class="{'offline-mode': mainCtrl.offlineMode.isEnabled()}"
           ng-show="!mainCtrl.embedded"
       >
       </ngeo-offline>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineNgeoComponent.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/offlineNgeoComponent.html
@@ -5,7 +5,9 @@
     </button>
   </span>
   <span ng-if="$ctrl.hasData()">
-    <div class="with-data" ng-click="$ctrl.showMenu()"></div>
+    <button class="with-data" ng-click="$ctrl.showMenu()">
+      <i class="fa fa-arrow-circle-o-down" aria-hidden="true"></i>
+    </button>
   </span>
 </div>
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -37,7 +37,7 @@ ngeo-offline, lux-offline {
       cursor: not-allowed;
     }
     .with-data {
-      color: red;
+      color: red !important;
     }
   }
   .db-button {right: 52px}
@@ -45,7 +45,7 @@ ngeo-offline, lux-offline {
   &.offline-mode {
     .main-button {
       .no-data, .with-data{
-        color: green;
+        color: green !important;
       }
     }
   }
@@ -60,7 +60,6 @@ ngeo-offline, lux-offline {
   }
 
   .offline-btn {
-      // width: 20rem;
       margin: 5px;
       i {
         margin-left: 6px;


### PR DESCRIPTION
The ngeo-offline button was broken by https://github.com/Geoportail-Luxembourg/geoportailv3/commit/412f1eb0722a198d4a0aa9126f9ace5448a97f7c (which modified the button display for the native iOS app)

This PR should fix the 'arrow down' icon to be displayed in green (active) or red (inactive). The CSS `!important` is needed to overwrite the `ol-control` color, a class added in the iOS fix above.

To-do:

- [ ] Test button on iOS
- [x] Verify download process works fine => layers (other than background) are currently not displayed after download (on production and migration)