### PR TITLE
GSLUX-617: Integrate LayerPanel

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -18,47 +18,21 @@ import 'angular';
 import 'angular-gettext';
 import 'angular-dynamic-locale';
 
-// import { defineCustomElement } from 'vue';
-
-// setTimeout(() => {
-//   const app = createApp({});
-//   // app.component('mybutton', MyButtonVue);
-//   app.mount('#vuejsinside');
-//   // app.component('testbutton', MyButtonVue);
-//   console.log("mybutton", app.component('mybutton'))
-// }, 2000)
-
-
-
 import { app, App, i18next as Luxi18next, createElementInstance, defineCustomElement, 
   createPinia, VueDOMPurifyHTML, backend, I18NextVue, storeToRefs, watch,
-  DropdownList, LayerManager, CatalogTree, ThemeSelector, LayerPanel,
-  MapContainer, BackgroundSelector, LayerMetadata, RemoteLayers, HeaderBar, 
+  DropdownList, LayerPanel, MapContainer, BackgroundSelector, LayerMetadata, RemoteLayers, HeaderBar, 
   useMap, useAppStore, useThemeStore, statePersistorLayersService, statePersistorThemeService,
   themeSelectorService } 
   from "luxembourg-geoportail/bundle/lux.dist.mjs";
 
-// const app = createApp(App)
-// app.use(createPinia())
-// app.use(I18NextVue, { Luxi18next })
-// app.use(VueDOMPurifyHTML)
-
 statePersistorLayersService.bootstrap()
+statePersistorThemeService.bootstrap()
 
+// LayerPanel includes Catalog, ThemeSelector, LayerManager
+// Note: Themes are now handled by new theme-selector
+// MainController watches useThemeStore().theme via vue watch to affect changes necessary for the legacy code
 const LayerPanelElement = createElementInstance(LayerPanel, app)
 customElements.define('layer-panel', LayerPanelElement)
-
-const CatalogElement = createElementInstance(CatalogTree, app)
-customElements.define('catalog-tree', CatalogElement)
-
-// Themes are now handled by new theme-selector:
-// MainController watches useThemeStore().theme via vue watch to affect changes necessary for the legacy code
-statePersistorThemeService.bootstrap()
-const ThemeSelectorElement = createElementInstance(ThemeSelector, app)
-customElements.define('theme-selector', ThemeSelectorElement)
-
-const LayerManagerElement = createElementInstance(LayerManager, app)
-customElements.define('layer-manager', LayerManagerElement)
 
 const MapContainerElement = createElementInstance(MapContainer, app)
 customElements.define('map-container', MapContainerElement)

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1942,24 +1942,13 @@ MainController.prototype.toggleThemeSelector = function() {
       this.showTab('a[href=\'#catalog\']');
       themesSwitcher.collapse('show');
       layerTree.collapse('hide');
-      this.toggleCatalogTree(false);
     }
   } else {
     this['layersOpen'] = true;
     this.showTab('a[href=\'#catalog\']');
     themesSwitcher.collapse('show');
     layerTree.collapse('hide');
-    this.toggleCatalogTree(false);
   }
-};
-
-/**
- * Toggle Custom Element <catalog-tree>
- * @return {boolean} show: if true force show, if false, force hide, otherwise, toggle.
- * @export
- */
-MainController.prototype.toggleCatalogTree = function(show) {
-  $('#catalog-tree').toggle(show ?? undefined);
 };
 
 /**

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -47,7 +47,7 @@
     </script>
   </head>
 
-  <body data-theme="{{mainCtrl.getEncodedCurrentTheme()}}" ng-class="{'offline-or-disconnected': mainCtrl.isDisconnectedOrOffline(), 'search-mobile': mainCtrl.mobileSearchActive, 'enabled-3d': mainCtrl.is3dEnabled(), 'embedded': mainCtrl.embedded, 'full': !mainCtrl.embedded}">
+  <body ng-class="{'offline-or-disconnected': mainCtrl.isDisconnectedOrOffline(), 'search-mobile': mainCtrl.mobileSearchActive, 'enabled-3d': mainCtrl.is3dEnabled(), 'embedded': mainCtrl.embedded, 'full': !mainCtrl.embedded}">
     
     
     <!-- Begin fixed top bar -->
@@ -143,11 +143,11 @@
               </div>
             </div>
             <div id="catalog" class="tab-pane active">
-              <app-themeswitcher app-themeswitcher-useropen="mainCtrl.userOpen"
+              <!-- <app-themeswitcher app-themeswitcher-useropen="mainCtrl.userOpen"
                                  app-themeswitcher-map="::mainCtrl.map"
-                                 ng-click="mainCtrl.toggleCatalogTree();"></app-themeswitcher>
+                                 ng-click="mainCtrl.toggleCatalogTree();"></app-themeswitcher> -->
               <!-- <app-catalog app-catalog-map="::mainCtrl.map"></app-catalog> -->
-              <!-- <theme-selector></theme-selector> -->
+              <theme-selector></theme-selector>
               <catalog-tree id="catalog-tree" class="h-full inline bg-primary px-2.5 overflow-y-auto" style="margin-top: -0.625rem;"></catalog-tree>
             </div>
           </div>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -115,42 +115,7 @@
            app-resizemap="mainCtrl.map" app-resizemap-state="mainCtrl.sidebarOpen()">
         <!-- Layers -->
         <div id="layers" ng-class="mainCtrl.layersOpen ? 'show' : 'hide'">
-          <h2 translate>layers</h2>
-          <button class="close-panel" ng-click="mainCtrl.closeSidebar()">
-            ✕
-          </button>
-          <ul class="nav nav-tabs">
-            <li role="presentation" class="my-layers-tab">
-              <a href="#mylayers" data-toggle="tab">
-                <span translate>my_layers</span>
-                <span ng-if="mainCtrl.selectedLayersLength() > 0">({{mainCtrl.selectedLayersLength()}})</span>
-              </a>
-            </li>
-            <li role="presentation" class="active catalog-tab">
-              <a href="#catalog" data-toggle="tab" translate>Catalog</a>
-            </li>
-          </ul>
-          <div class="tab-content">
-            <div id="mylayers" class="tab-pane col-xs-12">
-              <layer-manager></layer-manager>
-              <!-- <app-layermanager app-layermanager-map="::mainCtrl.map"
-                app-layermanager-layers="::mainCtrl.selectedLayers"
-                app-layermanager-active-layers-comparator="mainCtrl.activeLayersComparator">
-              </app-layermanager> -->
-              <div class="text-center add-layers">
-                <button class="btn btn-default" ng-click="mainCtrl.showTab('a[href=\'#catalog\']');" translate>+ Add layers</button>
-                <app-external-data app-external-data-map="::mainCtrl.map"></app-external-data>
-              </div>
-            </div>
-            <div id="catalog" class="tab-pane active">
-              <!-- <app-themeswitcher app-themeswitcher-useropen="mainCtrl.userOpen"
-                                 app-themeswitcher-map="::mainCtrl.map"
-                                 ng-click="mainCtrl.toggleCatalogTree();"></app-themeswitcher> -->
-              <!-- <app-catalog app-catalog-map="::mainCtrl.map"></app-catalog> -->
-              <theme-selector></theme-selector>
-              <catalog-tree id="catalog-tree" class="h-full inline bg-primary px-2.5 overflow-y-auto" style="margin-top: -0.625rem;"></catalog-tree>
-            </div>
-          </div>
+          <layer-panel></layer-panel>
         </div>
 
         <!-- MyMaps -->

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -386,9 +386,8 @@
     <div class="absolute right-1" style="top: 1rem">
       <background-selector></background-selector>
     </div>
-
     <layer-metadata></layer-metadata>
-
+    <remote-layers></remote-layers>
   </div>
 
     <!-- Begin bottom bar -->

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/externaldata/externaldata.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/externaldata/externaldata.html
@@ -9,7 +9,7 @@
   </div>
   <div class="modal-body">
     <!--TODO: adapt internal style of remote-layers element => not absolute, etc. currently also appears twice -->
-    <remote-layers></remote-layers>
+    <!-- <remote-layers></remote-layers> -->
   <!-- <div class="form-inline">
     <div class="dropdown">
      <div class="form-group">

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/themeswitcher/ThemeswitcherController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/themeswitcher/ThemeswitcherController.js
@@ -12,7 +12,6 @@ import appNotifyNotificationType from '../NotifyNotificationType.js';
 import appEventsThemesEventType from '../events/ThemesEventType.js';
 import {listen} from 'ol/events.js';
 
-import { themeSelectorService, useThemeStore } from "luxembourg-geoportail/bundle/lux.dist.mjs";
 /**
  * @constructor
  * @param {angularGettext.Catalog} gettextCatalog Gettext catalog.
@@ -144,9 +143,6 @@ exports.prototype.setThemes_ = function() {
  */
 exports.prototype.switchTheme = function(themeId) {
   this.appTheme_.setCurrentTheme(themeId);
-  //set theme and color for vue custom elements
-  useThemeStore().setTheme(themeId)
-  themeSelectorService.setCurrentThemeColors(themeId)
 };
 
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/offline.less
@@ -26,7 +26,6 @@ ngeo-offline, lux-offline {
     .no-data, .with-data {
       background-color: white;
       text-align: center;
-      font-size: 2.7rem;
       color: #2980b9;
       width: 41px;
       height: 41px;

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#GSLUX-602-IntegrationV3"
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#GSLUX-617-themeselector"
   ,
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#GSLUX-617-themeselector"
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#GSLUX-602-Integration-v3"
   ,
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-617

### Description

Based on https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/49 PR integrates the `LayerPanel`, mainly handling state changes of `layersOpen` for the sidebar and `theme` for applying correct colors on legacy components and custom elements.

Todo:

- [x] there still seems to be a problem with some tailwind classes to be applied to ensure correct spacing around the "Layers" title

Todos for separate PRs:
- integrate the remote layers element in a modal (along with layer metadata element)
- integrate the style selctors