### PR TITLE
GSLUX-627: Init sentry

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1398,13 +1398,12 @@ const MainController = function(
   ngeoOfflineServiceManager.setSaveService(appOfflineDownloader);
   ngeoOfflineServiceManager.setRestoreService(appOfflineRestorer);
 
-  // TODO: init sentry at a later stage of the integration. requests currently bother dev
-  // Sentry.init({
-  //   dsn: 'https://afe219319897490e9ba927b06afdf934@sentry.geoportail.lu/3',
-  //   integrations: [
-  //     new Integrations.Angular(),
-  //   ],
-  // });
+  Sentry.init({
+    dsn: 'https://afe219319897490e9ba927b06afdf934@sentry.geoportail.lu/3',
+    integrations: [
+      new Integrations.Angular(),
+    ],
+  });
 
   $('#editor-simple').on('show.bs.collapse', function(){
     this.trackOpenVTEditor('openVTSimpleEditor');


### PR DESCRIPTION
PR inits sentry as it was the case before the vue integration. Now does not seem to throw errors in console anymore.