### PR TITLE
GSLUX-631: Background selector KO

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
@@ -622,12 +622,19 @@ exports.prototype.initBgLayers_ = function() {
       stateBgLayerOpacity = this.ngeoLocation_.getParam('bgOpacity');
     }
     var hasBgLayerInUrl = (this.ngeoLocation_.getParam('bgLayer') !== undefined);
-    if (mapId === undefined || hasBgLayerInUrl) {
-      var layer = /** @type {ol.layer.Base} */ (bgLayers.find(layer => layer.get('label') === stateBgLayerLabel));
-      if (layer !== undefined) {
-        this.backgroundLayerMgr_.set(this.map_, layer);
-      }
-    }
+
+    // ------------------------------------------ //
+    // --------  UPDATE With new Lux lib -------- //
+    // ------------------------------------------ //
+    // - deactivate setting bg here as this is now handled by Permalink v4
+    // ------------------------------------------ //
+
+    // if (mapId === undefined || hasBgLayerInUrl) {
+    //   var layer = /** @type {ol.layer.Base} */ (bgLayers.find(layer => layer.get('label') === stateBgLayerLabel));
+    //   if (layer !== undefined) {
+    //     this.backgroundLayerMgr_.set(this.map_, layer);
+    //   }
+    // }
   });
 }
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/StateManager.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/StateManager.js
@@ -129,26 +129,26 @@ const exports = function(ngeoLocation, appNotify, gettextCatalog) {
     this.version_ = this.initialState_.hasOwnProperty('version') ?
         clamp(+this.initialState_['version'], 2, 3) : 2;
   }
-  var mapId = this.ngeoLocation_.getParam('map_id');
-  if (mapId === undefined &&
-      !((this.initialState_.hasOwnProperty('bgLayer') &&
-      this.initialState_['bgLayer'].length > 0 &&
-      this.initialState_['bgLayer'] != 'blank') ||
-      (this.initialState_.hasOwnProperty('layers') &&
-      this.initialState_['layers'].length > 0) ||
-      (this.initialState_.hasOwnProperty('fid') &&
-      this.initialState_['fid'].length > 0))) {
-    this.initialState_['bgLayer'] = 'basemap_2015_global';
-    this.ngeoLocation_.updateParams({'bgLayer': 'basemap_2015_global'});
-    var msg = this.gettextCatalog_.getString(
-        'Aucune couche n\'étant définie pour cette carte,' +
-        ' une couche de fond a automatiquement été ajoutée.');
-    this.notify_(msg, appNotifyNotificationType.INFO);
-  }
+  // var mapId = this.ngeoLocation_.getParam('map_id');
+  // if (mapId === undefined &&
+  //     !((this.initialState_.hasOwnProperty('bgLayer') &&
+  //     this.initialState_['bgLayer'].length > 0 &&
+  //     this.initialState_['bgLayer'] != 'blank') ||
+  //     (this.initialState_.hasOwnProperty('layers') &&
+  //     this.initialState_['layers'].length > 0) ||
+  //     (this.initialState_.hasOwnProperty('fid') &&
+  //     this.initialState_['fid'].length > 0))) {
+  //   this.initialState_['bgLayer'] = 'basemap_2015_global';
+  //   this.ngeoLocation_.updateParams({'bgLayer': 'basemap_2015_global'});
+  //   var msg = this.gettextCatalog_.getString(
+  //       'Aucune couche n\'étant définie pour cette carte,' +
+  //       ' une couche de fond a automatiquement été ajoutée.');
+  //   this.notify_(msg, appNotifyNotificationType.INFO);
+  // }
 
   console.assert(this.version_ != -1);
 
-  this.ngeoLocation_.updateParams({'version': 3});
+  // this.ngeoLocation_.updateParams({'version': 3});
 };
 
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -18,15 +18,35 @@ import 'angular';
 import 'angular-gettext';
 import 'angular-dynamic-locale';
 
-import { app, i18next as Luxi18next, createElementInstance,
-  storeToRefs, watch,
-  LayerPanel, MapContainer, BackgroundSelector, LayerMetadata, RemoteLayers, HeaderBar, 
-  useMap, useAppStore, useMapStore, useThemeStore, statePersistorLayersService, statePersistorThemeService,
-  themeSelectorService, SliderComparator } 
-  from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import { 
+  app,
+  i18next as Luxi18next,
+  createElementInstance,
+  storeToRefs,
+  watch,
+  AlertNotifications,
+  LayerPanel,
+  MapContainer,
+  BackgroundSelector,
+  LayerMetadata,
+  RemoteLayers,
+  HeaderBar, 
+  useMap,
+  useAppStore,
+  useMapStore,
+  useThemeStore,
+  statePersistorBgLayerService,
+  statePersistorLayersService,
+  statePersistorThemeService,
+  statePersistorMyMapService,
+  themeSelectorService, SliderComparator
+} from "luxembourg-geoportail/bundle/lux.dist.mjs";
 
+// Important! keep order
+statePersistorMyMapService.bootstrap()
 statePersistorLayersService.bootstrap()
 statePersistorThemeService.bootstrap()
+statePersistorBgLayerService.bootstrap()
 
 // LayerPanel includes Catalog, ThemeSelector, LayerManager
 // Note: Themes are now handled by new theme-selector
@@ -48,6 +68,9 @@ customElements.define('remote-layers', RemoteLayersElement)
 
 const SliderComparatorElement = createElementInstance(SliderComparator, app)
 customElements.define('slider-comparator', SliderComparatorElement)
+
+const AlertNotificationsElement = createElementInstance(AlertNotifications, app)
+customElements.define('alert-notifications', AlertNotificationsElement)
 
 import i18next from 'i18next';
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -48,8 +48,8 @@
   </head>
 
   <body ng-class="{'offline-or-disconnected': mainCtrl.isDisconnectedOrOffline(), 'search-mobile': mainCtrl.mobileSearchActive, 'enabled-3d': mainCtrl.is3dEnabled(), 'embedded': mainCtrl.embedded, 'full': !mainCtrl.embedded}">
-    
-    
+    <alert-notifications></alert-notifications>
+
     <!-- Begin fixed top bar -->
     <header class="navbar navbar-default navbar-fixed-top" role="navigation" ng-show="::!mainCtrl.embedded">
       <div class="container-fluid">

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -109,10 +109,14 @@
       <button class="routing-rounded-button" ng-click="mainCtrl.routingOpen=true;" translate>Itinéraire en détail</button>
     </div>
     <!-- Begin page content (ie. map + left sidebar) -->
-    <div id="main-container" ng-class="{'gmf-lidarprofile-chart-active': mainCtrl.lidarOpen}"
-      class="flex grow">
-      <div id="sidebar" ng-class="{open: mainCtrl.sidebarOpen()}"
-           app-resizemap="mainCtrl.map" app-resizemap-state="mainCtrl.sidebarOpen()">
+    <div id="main-container"
+      ng-class="{'gmf-lidarprofile-chart-active': mainCtrl.lidarOpen}"
+      >
+      <div id="sidebar"
+        style="z-index: 50;"
+        ng-class="{open: mainCtrl.sidebarOpen()}"
+        app-resizemap="mainCtrl.map"
+        app-resizemap-state="mainCtrl.sidebarOpen()">
         <!-- Layers -->
         <div id="layers" ng-class="mainCtrl.layersOpen ? 'show' : 'hide'">
           <layer-panel></layer-panel>
@@ -336,9 +340,11 @@
           </div>
           </div>
         </div>
-      </div>
-    <div class="map-wrapper grow relative">
-      <map-container app-resizemap="mainCtrl.map" app-resizemap-state="mainCtrl.open">
+    </div>
+    <div class="map-wrapper relative">
+      <map-container
+        style="position: relative; width:auto; overflow: hidden;"
+        >
         <app-toggle-offline></app-toggle-offline>
         <app-toggle-3d></app-toggle-3d>
         <app-infobar app-infobar-map="::mainCtrl.map"></app-infobar>
@@ -373,9 +379,9 @@
         class="background-layer"
         app-backgroundselector-map="::mainCtrl.map">
       </app-backgroundselector> -->
-    </div>
-    <div class="absolute right-1" style="top: 1rem">
-      <background-selector></background-selector>
+      <div class="absolute right-1" style="top: 1rem">
+        <background-selector></background-selector>
+      </div>
     </div>
     <layer-metadata></layer-metadata>
     <remote-layers></remote-layers>

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/resizemapDirective.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/resizemapDirective.js
@@ -14,11 +14,14 @@
 
 import appModule from './module.js';
 import olMap from 'ol/Map.js';
-
+import offlineUtils from 'ngeo/offline/utils.js';
 
 function resizeMap(map) {
   map.updateSize();
   map.renderSync();
+
+  // TODO: To be commented when PR no-ol in v4 is OK
+  // For newer version of Ol
   map.getAllLayers().forEach(layer => {
     if (layer.maplibreMap) {
       layer.maplibreMap.resize();
@@ -28,6 +31,18 @@ function resizeMap(map) {
       layer.getMapBoxMap().resize();
     }
   });
+
+  // TODO: To be uncommented when PR no-ol in v4 is OK
+  // Rollback traverse layers since we downgraded ol version in v4 (map.getAllLayers() not available)
+  // offlineUtils.traverseLayer(map.getLayerGroup(), [], layer => {
+  //   if (layer.maplibreMap) {
+  //     layer.maplibreMap.resize();
+  //   }
+
+  //   if (layer.getMapBoxMap) {
+  //     layer.getMapBoxMap().resize();
+  //   }
+  // });
 }
 
 /**

--- a/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/less/geoportailv3.less
@@ -292,3 +292,7 @@ div[data-toggle="collapse"] {
   }
   padding: 10px;
 }
+
+.lux-notifications {
+  z-index: 2000 !important;
+}

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#30c3488063d86c072190c6f90d271641c0855533",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#dc4dbe5ad2fe25be8bffb051824c21743de94b3c",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
Please test this PR with this v3 PR : https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/63

<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-631

### Description

Background selection was not working as expected in v3.

- enable blank bg selection in v3 (bg `ZIndex` is now `-200` (instead of -1) like in v3 legacy
- handle special case: when **bg layer is blank** in permalink **and no layers** in permalink (was not working)
- added new component for alert notifications (when bg layer is blank in permalink and no layers in permalink, it now displays the message in an alert box, instead of display message with a `console.log`)
- added e2e tests

Some more stuffs:
- npm commands for building lib dev: disable minification in dev mode for debug purpose
- do not import main.css in ol.css, causing duplicated styles in the dom


### Screenshots

![image](https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/assets/115457104/c8aa115a-6a77-4268-aae1-aad5d4f9420d)