### PR TITLE
GSLUX-633: On click theme button in header

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1963,6 +1963,8 @@ MainController.prototype.showTab = function(selector) {
  * @export
  */
 MainController.prototype.toggleThemeSelector = function() {
+  const { layersOpen, myLayersTabOpen, themeGridOpen } = storeToRefs(useAppStore())
+
   var layerTree = $('app-catalog .themes-switcher');
   var themesSwitcher = $('app-themeswitcher #themes-content');
   var themeTab = $('#catalog');
@@ -1980,6 +1982,19 @@ MainController.prototype.toggleThemeSelector = function() {
     this.showTab('a[href=\'#catalog\']');
     themesSwitcher.collapse('show');
     layerTree.collapse('hide');
+  }
+
+  if (!layersOpen.value) {
+    useAppStore().setLayersOpen(true)
+    myLayersTabOpen.value && useAppStore().setMyLayersTabOpen(false)
+    useAppStore().setThemeGridOpen(true)
+  } else if (layersOpen.value) {
+    if (themeGridOpen.value) {
+      useAppStore().setLayersOpen(false)
+    } else {
+      myLayersTabOpen.value && useAppStore().setMyLayersTabOpen(false)
+      useAppStore().setThemeGridOpen(true)
+    }
   }
 };
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1169,10 +1169,12 @@ const MainController = function(
       return this['layersOpen'];
     }, newVal => {
       if (newVal === false) {
-        $('app-catalog .themes-switcher').collapse('show');
-        $('app-themeswitcher #themes-content').collapse('hide');
+        // $('app-catalog .themes-switcher').collapse('show');
+        // $('app-themeswitcher #themes-content').collapse('hide');
+
         // close style editor when switching tools and sidebar stays open
         useAppStore().closeStyleEditorPanel()
+        useAppStore().setThemeGridOpen(false)
       } else {
         this['lidarOpen'] = false;
       }
@@ -1760,6 +1762,8 @@ MainController.prototype.closeSidebar = function() {
       this['feedbackCruesOpen'] = this['vectorEditorOpen'] = this['lidarOpen'] = false;
   // close style editor when closing sidebar
   useAppStore().closeStyleEditorPanel()
+  useAppStore().setLayersOpen(false) // For info, this also closes the themeGrid
+  useAppStore().setMyLayersTabOpen(false)
 };
 
 

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#e0d5b174dc448fa9bb42391b4d8978f1be2c25c6",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#30c3488063d86c072190c6f90d271641c0855533",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
This PR needs: https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/64

<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-633

### Description

When clicking on theme button in the header, it should: 
- display the side panel (if not already displayed) and display the theme grid
- if the side panel is visible but the catalog tab is not selected, it should select the catalog tab and display the theme grid
- if the side panel and the theme grid are already visible, it should hide the side panel