### PR TITLE
GSLUX-620: Traductions manquantes pour les layers

### DIFF
--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#dc4dbe5ad2fe25be8bffb051824c21743de94b3c",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#a5e987a9ac2b4167424a244671e4df6cbe53cfc0",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
See
https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/68

<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-620

### Description

Translation files (for all lang) need an update.
Some translations are missing, especially for new layers.