### PR TITLE
Gslux 629 print

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/print/PrintController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/print/PrintController.js
@@ -474,7 +474,7 @@ exports.prototype.print = function(format) {
   var legend = [];
 
   var bgLayer = this.backgroundLayerMgr_.get(this.map_);
-  var bgMetadata = bgLayer.get('metadata');
+  var bgMetadata = bgLayer?.get('metadata');
   if (bgMetadata !== undefined) {
     var bgName = bgMetadata['legend_name'];
     if (bgName !== undefined) {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/print/Printservice.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/print/Printservice.js
@@ -9,6 +9,7 @@ import * as olMath from 'ol/math.js';
 import olStyleRegularShape from 'ol/style/RegularShape.js';
 import VectorEncoder from 'ngeo/print/VectorEncoder.js';
 import MapBoxLayer from '@geoblocks/mapboxlayer/src/MapBoxLayer.js';
+import {MapLibreLayer} from "luxembourg-geoportail/bundle/lux.dist.mjs";
 
 function rgbToHex(r, g, b) {
   return ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
@@ -213,7 +214,7 @@ const exports = class extends ngeoPrintService {
     layers.forEach((layer) => {
       if (layer.getVisible()) {
         console.assert(viewResolution !== undefined);
-        if (layer instanceof MapBoxLayer) {
+        if (layer instanceof MapBoxLayer || layer instanceof MapLibreLayer) {
           const xyz = layer.get('xyz_custom') || layer.getXYZ();
           if (xyz) {
             this.encodeXYZLayer_(object.layers, xyz);


### PR DESCRIPTION
fix the print service by catching the custom URLs for MapLibreLayers
The correct bg layer is already obtained thanks to https://github.com/Geoportail-Luxembourg/geoportailv3/pull/3093