### PR TITLE
GSLUX-601: Integrate new style selector

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -28,6 +28,7 @@ import {
   LayerPanel,
   MapContainer,
   BackgroundSelector,
+  StyleSelector,
   LayerMetadata,
   RemoteLayers,
   HeaderBar,
@@ -43,6 +44,7 @@ import {
   statePersistorLayersService,
   statePersistorThemeService,
   statePersistorMyMapService,
+  statePersistorStyleService,
   themeSelectorService,
   SliderComparator
 } from "luxembourg-geoportail/bundle/lux.dist.mjs";
@@ -51,6 +53,7 @@ import {
 statePersistorMyMapService.bootstrap()
 statePersistorLayersService.bootstrap()
 statePersistorThemeService.bootstrap()
+statePersistorStyleService.bootstrapStyle()
 statePersistorBgLayerService.bootstrap()
 
 const luxAppStore = useAppStore()
@@ -66,6 +69,9 @@ customElements.define('map-container', MapContainerElement)
 
 const BackgroundSelectorElement = createElementInstance(BackgroundSelector, app)
 customElements.define('background-selector', BackgroundSelectorElement)
+
+const StyleSelectorElement = createElementInstance(StyleSelector, app)
+customElements.define('style-selector', StyleSelectorElement)
 
 const LayerMetadataElement = createElementInstance(LayerMetadata, app)
 customElements.define('layer-metadata', LayerMetadataElement)

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -53,7 +53,8 @@ import {
 statePersistorMyMapService.bootstrap()
 statePersistorLayersService.bootstrap()
 statePersistorThemeService.bootstrap()
-statePersistorStyleService.bootstrapStyle()
+// styles must not be bootstrapped here as one would like to do naively, but themes must be loaded first
+// statePersistorStyleService.bootstrapStyle()
 statePersistorBgLayerService.bootstrap()
 
 const luxAppStore = useAppStore()
@@ -1173,6 +1174,8 @@ const MainController = function(
 
   this.manageUserRoleChange_($scope);
   this.loadThemes_().then((themes) => {
+    useThemeStore().setThemes(themes);
+    statePersistorStyleService.bootstrapStyle()
     this.appThemes_.getBgLayers(this.map_).then(
           bgLayers => {
             if (appOverviewMapShow) {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -289,54 +289,7 @@
             ✕
           </button>
           <div class="container-fluid tab-content">
-          <div class="accordion" id="accordion">
-            <div class="panel">
-              <div data-toggle="collapse" data-target="#editor-simple" class="editor-list" ng-if="mainCtrl.isColorVisible" translate>Simple</div>
-              <div class="collapse" id="editor-simple" ng-if="mainCtrl.isColorVisible" data-parent="#accordion">
-                <div class="content-wrapper">
-                  <div class="editor-content">
-                    <p translate>Sélectionner un set de couleurs</p>
-                    <app-simple-style
-                      on-styling-selected="mainCtrl.onSimpleStylingSelected"
-                      stylings="mainCtrl.simpleStylingData">
-                    </app-simple-style>
-                  </div>
-                </div>
-              </div>
-              <div data-toggle="collapse" data-target="#editor-medium" class="editor-list" translate>Medium</div>
-              <div class="collapse" id="editor-medium" data-parent="#accordion">
-                <div class="content-wrapper">
-                  <div class="editor-content">
-                    <p ng-if="mainCtrl.isColorVisible" translate>Sélectionner une couleur par couche</p>
-                    <p ng-if="!mainCtrl.isColorVisible" translate>Afficher une catégorie par couche</p>
-                    <app-medium-style
-                      on-styling-changed="mainCtrl.onMediumStylingChanged"
-                      stylings="mainCtrl.mediumStylingData">
-                    </app-medium-style>
-                  </div>
-                </div>
-              </div>
-              <div data-toggle="collapse" data-target="#editor-expert" class="editor-list" translate>Expert (style.json)</div>
-              <div class="collapse" id="editor-expert" data-parent="#accordion">
-                <div class="content-wrapper">
-                  <div id="editor-expert-content">
-                    <p translate>Lancer éditeur externe ou importer json</p>
-                    <a href class="launch-editor-button" ng-click="mainCtrl.downloadCustomStyleFile()"><span translate>Download style</span></a>
-                    <div class="upload-style-button">
-                      <label for="uploadMvtStyle"><span translate>Upload style</span></label>
-                      <input
-                        type="file"
-                        name="uploadMvtStyle"
-                        id="uploadMvtStyle"
-                        custom-on-change="mainCtrl.setCustomStyle">
-                    </div>
-                    <a href="https://maputnik.github.io/editor/?style={{mainCtrl.getUrlVtStyle()}}" target="_blank" class="btn btn-default" translate>Open Maputnik editor</a>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <a class="btn btn-default clear-style-btn" ng-click="mainCtrl.clearCustomStyle()" ng-if="mainCtrl.appMvtStylingService.isCustomStyle" translate>Réinitialiser Style</a>
-          </div>
+            <style-selector/>
           </div>
         </div>
     </div>

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#3cf5e87cd5b2a743c255ff4ec06f5c597496a104",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#afebadf0d7021028eebd4fa777f4eabc3d7e9895",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#cc680ac3041cf2be7a3543b88d5b9428e11cfc4d",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#3cf5e87cd5b2a743c255ff4ec06f5c597496a104",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
The goal of this PR is to integrate the new style selector. Use the new style selector with the remaining issues to be solved.

Current issue / to-dos: 

- [x] replace v3 `getBgStyle` with v4 `bgStyle`, maybe more adaptions necessary
=> currently seems to cause permalink `bgLayer` not always updating if a customized style object is present (in permalink or localstorage)
=> also causes `setConfigForLayer_` error in console when reloading app after modifying style
- [x] update `serialLayer` correctly in permalink => (see also `setConfigForLayer_`)

- print after style modification works locally only when not using `vectortiles-print.geoportail.lu` here: https://github.com/Geoportail-Luxembourg/geoportailv3/blob/GSLUX-601-style-selector/geoportal/geoportailv3_geoportal/views/luxprintproxy.py#L226 (does not seem related to this PR)

- [x] still needs update of v4 dependency before merge