### PR TITLE
GSLUX-656: Lost background when using bg switcher

### DIFF
--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#cc680ac3041cf2be7a3543b88d5b9428e11cfc4d",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#1e577fd5faf3d0426a44ce0733c95281ceebd199",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
It looks like it is fixed when lux lib is up to date (use last commit `1e577fd5faf3d0426a44ce0733c95281ceebd199`).