### PR TITLE
GSLUX-608 Activate UglifyPlugin

### DIFF
--- a/geoportal/CONST_Makefile
+++ b/geoportal/CONST_Makefile
@@ -107,7 +107,7 @@ $(APP_OUTPUT_DIR)/vendor%: /opt/vendor%
 
 apps: webpack.apps.js
 	rm --force $(addprefix $(APP_OUTPUT_DIR)/, $(addsuffix .*, $(NGEO_INTERFACES)))
-	webpack $(WEBPACK_ARGS)
+	node --max-old-space-size=4096 /usr/lib/node_modules/webpack/bin/webpack.js $(WEBPACK_ARGS)
 	for interface in $(NGEO_INTERFACES); \
 	do \
 		mv $(APP_OUTPUT_DIR)/$${interface}.html $(APP_OUTPUT_DIR)/$${interface}.html.tmpl; \

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
@@ -11,7 +11,7 @@ import appNotifyNotificationType from './NotifyNotificationType.js';
 import appEventsThemesEventType from './events/ThemesEventType.js';
 import {listen, unlistenByKey} from 'ol/events.js';
 import {extend as arrayExtend} from 'ol/array.js';
-import { useMapStore } from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import { useMapStore } from "luxembourg-geoportail/bundle/lux.dist.js";
 
 
 /**

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/Themes.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/Themes.js
@@ -373,7 +373,13 @@ Themes.findTheme_ = function(themes, themeName) {
 };
 
 
-appModule.service('appThemes', Themes);
+appModule.service('appThemes', ['$window', '$http', 'gmfTreeUrl', 'isThemePrivateUrl',
+  'appGetWmtsLayer', 'appBlankLayer', 'appGetDevice', 'appMvtStylingService', 
+  function($window, $http, gmfTreeUrl, isThemePrivateUrl,
+    appGetWmtsLayer, appBlankLayer, appGetDevice, appMvtStylingService) {
+  return new Themes($window, $http, gmfTreeUrl, isThemePrivateUrl,
+    appGetWmtsLayer, appBlankLayer, appGetDevice, appMvtStylingService);
+}]);
 
 
 export default Themes;

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -47,7 +47,7 @@ import {
   statePersistorStyleService,
   themeSelectorService,
   SliderComparator
-} from "luxembourg-geoportail/bundle/lux.dist.mjs";
+} from "luxembourg-geoportail/bundle/lux.dist.js";
 
 // Important! keep order
 statePersistorMyMapService.bootstrap()

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/bootstrap.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/bootstrap.js
@@ -68,7 +68,9 @@ function bootstrap(module) {
     }
     setupI18n();
 
-    angular.bootstrap(document, [`App${interface_}`]);
+    angular.bootstrap(document, [`App${interface_}`], {
+      strictDi: true
+    });
   });
 }
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/mvtstyling/MvtStylingService.js
@@ -1,7 +1,7 @@
 import { _ } from 'core-js';
 import appModule from '../module.js';
 import { isValidSerial } from '../utils.js';
-import { useOpenLayers, useMapStore , useMvtStyles, useStyleStore, storeToRefs } from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import { useOpenLayers, useMapStore , useMvtStyles, useStyleStore, storeToRefs } from "luxembourg-geoportail/bundle/lux.dist.js";
 
 function hasLocalStorage() {
     try {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/olcs/Lux3DManager.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/olcs/Lux3DManager.js
@@ -9,7 +9,7 @@ import appNotifyNotificationType from '../NotifyNotificationType.js';
 import OLCesium from 'olcs/OLCesium.js';
 import LuxRasterSynchronizer from './LuxRasterSynchronizer';
 import VectorSynchronizer from 'olcs/VectorSynchronizer';
-import { useOpenLayers, useMapStore, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import { useOpenLayers, useMapStore, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.js";
 
 
 class Wrap3dLayer {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/olcs/LuxRasterSynchronizer.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/olcs/LuxRasterSynchronizer.js
@@ -1,6 +1,6 @@
 import RasterSynchronizer from 'olcs/RasterSynchronizer';
 import MapBoxLayer from '@geoblocks/mapboxlayer/src/MapBoxLayer.js';
-import {MapLibreLayer} from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import {MapLibreLayer} from "luxembourg-geoportail/bundle/lux.dist.js";
 import {XYZ} from 'ol/source';
 import {Tile as TileLayer} from 'ol/layer';
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/print/Printservice.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/print/Printservice.js
@@ -9,7 +9,7 @@ import * as olMath from 'ol/math.js';
 import olStyleRegularShape from 'ol/style/RegularShape.js';
 import VectorEncoder from 'ngeo/print/VectorEncoder.js';
 import MapBoxLayer from '@geoblocks/mapboxlayer/src/MapBoxLayer.js';
-import {MapLibreLayer} from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import {MapLibreLayer} from "luxembourg-geoportail/bundle/lux.dist.js";
 
 function rgbToHex(r, g, b) {
   return ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
@@ -33,7 +33,7 @@ import Fuse from 'fuse.js';
 import { matchCoordinate } from '../CoordinateMatch'
 import olcsCore from 'olcs/core.js';
 
-import { useLayers, useThemes, useThemeStore, useBackgroundLayer, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import { useLayers, useThemes, useThemeStore, useBackgroundLayer, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.js";
 
 
 /**

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/buildtools/webpack.prod.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/buildtools/webpack.prod.js
@@ -41,14 +41,15 @@ module.exports = function(UglifyJsPluginCache) {
     },
     optimization: {
       minimizer: [
-        // new UglifyJsPlugin({
-        //   cache: UglifyJsPluginCache,
-        //   parallel: true,
-        //   sourceMap: true,
-        //   uglifyOptions: {
-        //     compress: false
-        //   }
-        // })
+        new UglifyJsPlugin({
+          cache: UglifyJsPluginCache,
+          parallel: true,
+          sourceMap: true,
+          uglifyOptions: {
+            compress: false
+          },
+          exclude: '/node_modules/luxembourg-geoportail',
+        })
       ]
     },
     resolve: {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/buildtools/webpack.prod.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/buildtools/webpack.prod.js
@@ -48,10 +48,6 @@ module.exports = function(UglifyJsPluginCache) {
           uglifyOptions: {
             compress: false
           },
-          exclude: [
-            '**/node_modules/luxembourg-geoportail/bundle/*',
-            '**/node_modules/mapbox-gl/dist/*'
-          ],
         })
       ]
     },

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/buildtools/webpack.prod.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/buildtools/webpack.prod.js
@@ -48,7 +48,10 @@ module.exports = function(UglifyJsPluginCache) {
           uglifyOptions: {
             compress: false
           },
-          exclude: '/node_modules/luxembourg-geoportail',
+          exclude: [
+            '**/node_modules/luxembourg-geoportail/bundle/*',
+            '**/node_modules/mapbox-gl/dist/*'
+          ],
         })
       ]
     },

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/map/BackgroundLayerMgr.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/map/BackgroundLayerMgr.js
@@ -12,7 +12,7 @@ import olSourceTileWMS from 'ol/source/TileWMS.js';
 import olSourceWMTS from 'ol/source/WMTS.js';
 import ngeoLayerHelper from 'ngeo/map/LayerHelper.js';
 
-import { useMapStore, useOpenLayers, useBackgroundLayer } from "luxembourg-geoportail/bundle/lux.dist.mjs";
+import { useMapStore, useOpenLayers, useBackgroundLayer } from "luxembourg-geoportail/bundle/lux.dist.js";
 
 
 const BACKGROUNDLAYERGROUP_NAME = 'background';

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#023c1df5643a526ead2c480a219085cdb9bdbf39",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#a738fddd49fe67a8416e746f02dd9dad1d123da5",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#a7e18ed20696605f8edd89437fea7bb3fbceba8a",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#a298743a1fcb1ad0a301c27131c8a94acc3059fb",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#a298743a1fcb1ad0a301c27131c8a94acc3059fb",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#c7256d0124a396963d6cde8b40434135105c8712",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#afebadf0d7021028eebd4fa777f4eabc3d7e9895",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#023c1df5643a526ead2c480a219085cdb9bdbf39",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#a738fddd49fe67a8416e746f02dd9dad1d123da5",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#a7e18ed20696605f8edd89437fea7bb3fbceba8a",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-608

### Description

The goal of this PR is to allow activating the `UglifyJsPlugin`.

To do so, it:
- uses the legacy build from https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/103
- raises the memory limit for webpack
- gets rid of minification issues in `Themes.js` detected via `strictDi: true`

To-dos:
- [x] remove `strictDi: true` => kept it to catch minification issues on dev in the future
- [x] remove exclusions in `UglifyJsPlugin` (to be tested)
- [x] revert `.js/.mjs` modifications and handle according version for dev and prod => kept .js extension (since `prod` is no `mjs` anymore), coping both `dev` and `prod` sources to a `lux.dist.js` file after lib build
- [x] cleanup and test