### PR TITLE
GSLUX-698: FIX init bg config AFTER urls init

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -767,12 +767,15 @@ const MainController = function(
   this.mapStore_ = useMapStore()
   this.styleStore_ = useStyleStore()
   this.styleService_ = useMvtStyles()
+
   this.styleService_.setRegisterUrl_v3({
     get: getvtstyleUrl,
     upload: uploadvtstyleUrl,
     delete: deletevtstyleUrl,
     vectortiles: vectortilesUrl
   })
+
+  this.styleService_.initBackgroundsConfigs()
 
   /**
    * @type {app.draw.DrawnFeatures}

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#cb91777d4dbd51bbe82d5d271e29a4583c1e7c35",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#ed3d13c8637ac3abc611864033d0c6a3b4586b12",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-698

### Description

Add init bg configs function, this initialization must be made AFTER vectortiles url initialization (this a a patch for v3)