### PR TITLE
GSLUX-701: Missing text "No layer selected" when offline

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/Mymaps.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/Mymaps.js
@@ -25,7 +25,7 @@ import olStyleStyle from 'ol/style/Style.js';
 import {get as getProj, transform} from 'ol/proj.js';
 import olcsCore from 'olcs/core.js';
 
-import { useMapStore, useThemeStore, useBackgroundLayer, useLayers, useThemes, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.js";
+import { useAppStore, useMapStore, useThemeStore, useBackgroundLayer, useThemes, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.js";
 
 /**
  * @constructor
@@ -485,6 +485,9 @@ exports.prototype.setMapId = function(mapId) {
   this.stateManager_.updateState({
     'map_id': this.mapId_
   });
+
+  // v4 Set map id MyMaps in lib
+  useAppStore().setMapId(this.mapId_);
 };
 
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/mymaps/MymapsController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/mymaps/MymapsController.js
@@ -23,6 +23,9 @@ import olGeomLineString from 'ol/geom/LineString.js';
 import * as olExtent from 'ol/extent.js';
 import JSZip from 'jszip';
 
+import { useAppStore } from "luxembourg-geoportail/bundle/lux.dist.js";
+
+
 /**
  * @param {!angular.Scope} $scope Scope.
  * @param {angular.$compile} $compile The compile provider.
@@ -820,6 +823,9 @@ exports.prototype.closeMap = function() {
   this.selectedFeatures_.clear();
   this['layersChanged'] = false;
   this.appFeaturePopup_.hide();
+
+  // v4 Set map id MyMaps in lib
+  useAppStore().setMapId(undefined);
 };
 
 

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#206574c44d7f23c135348610067d64f1810c42d2",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#1dd6ef31a7264c1d6d72e85433f9c733c0ca8617",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-701

### Description

- Add missing text "No layer selected" when user switches to offline mode
- in v4: update icons and add new scholl theme (after merging main onto integration-vue)

NB. This PR needs v4 fix : https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/117