### PR TITLE
GSLUX-720: Fix reading permalink containing 3d_enabled

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/LayerPermalinkManager.js
@@ -594,55 +594,56 @@ exports.prototype.init = function(scope, map, selectedLayers) {
   this.initialized_ = true;
 };
 
-exports.prototype.initBgLayers_ = function() {
-  return this.appThemes_.getBgLayers(this.map_).then((bgLayers) => {
-    var stateBgLayerLabel, stateBgLayerOpacity;
-    var mapId = this.ngeoLocation_.getParam('map_id');
-    if (!this.initialized_) {
-      stateBgLayerLabel = this.stateManager_.getInitialValue('bgLayer');
-      stateBgLayerOpacity = this.stateManager_.getInitialValue('bgOpacity');
-      if ((stateBgLayerLabel !== undefined && stateBgLayerLabel !== null) ||
-          ((stateBgLayerOpacity !== undefined && stateBgLayerOpacity !== null) && parseInt(stateBgLayerOpacity, 0) === 0)) {
-        if (this.initialVersion_ === 2 && stateBgLayerLabel !== undefined && stateBgLayerLabel !== null) {
-          stateBgLayerLabel = exports.V2_BGLAYER_TO_V3_[stateBgLayerLabel];
-          if (stateBgLayerLabel === undefined) {
-            stateBgLayerLabel = "basemap_2015_global";
-          }
-        } else if (this.initialVersion_ === 2 && parseInt(stateBgLayerOpacity, 0) === 0) {
-          stateBgLayerLabel = 'orthogr_2013_global';
-        }
-      } else {
-        if (mapId === undefined) {
-          stateBgLayerLabel = 'basemap_2015_global';
-        } else {
-          if (this.appTheme_.getCurrentTheme() === 'tourisme') {
-            stateBgLayerLabel = 'topo_bw_jpeg';
-          } else {
-            stateBgLayerLabel = 'topogr_global';
-          }
-        }
-        stateBgLayerOpacity = 0;
-      }
-    } else {
-      stateBgLayerLabel = this.ngeoLocation_.getParam('bgLayer');
-      stateBgLayerOpacity = this.ngeoLocation_.getParam('bgOpacity');
-    }
-    var hasBgLayerInUrl = (this.ngeoLocation_.getParam('bgLayer') !== undefined);
+// This function is not called anymore at all
+// exports.prototype.initBgLayers_ = function() {
+//   return this.appThemes_.getBgLayers(this.map_).then((bgLayers) => {
+//     var stateBgLayerLabel, stateBgLayerOpacity;
+//     var mapId = this.ngeoLocation_.getParam('map_id');
+//     if (!this.initialized_) {
+//       stateBgLayerLabel = this.stateManager_.getInitialValue('bgLayer');
+//       stateBgLayerOpacity = this.stateManager_.getInitialValue('bgOpacity');
+//       if ((stateBgLayerLabel !== undefined && stateBgLayerLabel !== null) ||
+//           ((stateBgLayerOpacity !== undefined && stateBgLayerOpacity !== null) && parseInt(stateBgLayerOpacity, 0) === 0)) {
+//         if (this.initialVersion_ === 2 && stateBgLayerLabel !== undefined && stateBgLayerLabel !== null) {
+//           stateBgLayerLabel = exports.V2_BGLAYER_TO_V3_[stateBgLayerLabel];
+//           if (stateBgLayerLabel === undefined) {
+//             stateBgLayerLabel = "basemap_2015_global";
+//           }
+//         } else if (this.initialVersion_ === 2 && parseInt(stateBgLayerOpacity, 0) === 0) {
+//           stateBgLayerLabel = 'orthogr_2013_global';
+//         }
+//       } else {
+//         if (mapId === undefined) {
+//           stateBgLayerLabel = 'basemap_2015_global';
+//         } else {
+//           if (this.appTheme_.getCurrentTheme() === 'tourisme') {
+//             stateBgLayerLabel = 'topo_bw_jpeg';
+//           } else {
+//             stateBgLayerLabel = 'topogr_global';
+//           }
+//         }
+//         stateBgLayerOpacity = 0;
+//       }
+//     } else {
+//       stateBgLayerLabel = this.ngeoLocation_.getParam('bgLayer');
+//       stateBgLayerOpacity = this.ngeoLocation_.getParam('bgOpacity');
+//     }
+//     var hasBgLayerInUrl = (this.ngeoLocation_.getParam('bgLayer') !== undefined);
 
-    // ------------------------------------------ //
-    // --------  UPDATE With new Lux lib -------- //
-    // ------------------------------------------ //
-    // - deactivate setting bg here as this is now handled by Permalink v4
-    // ------------------------------------------ //
+//     // ------------------------------------------ //
+//     // --------  UPDATE With new Lux lib -------- //
+//     // ------------------------------------------ //
+//     // - deactivate setting bg here as this is now handled by Permalink v4
+//     // ------------------------------------------ //
 
-    // if (mapId === undefined || hasBgLayerInUrl) {
-    //   var layer = /** @type {ol.layer.Base} */ (bgLayers.find(layer => layer.get('label') === stateBgLayerLabel));
-    //   if (layer !== undefined) {
-    //     this.backgroundLayerMgr_.set(this.map_, layer);
-    //   }
-    // }
-  });
-}
+//     // if (mapId === undefined || hasBgLayerInUrl) {
+//     //   var layer = /** @type {ol.layer.Base} */ (bgLayers.find(layer => layer.get('label') === stateBgLayerLabel));
+//     //   if (layer !== undefined) {
+//     //     this.backgroundLayerMgr_.set(this.map_, layer);
+//     //   }
+//     // }
+//   });
+// }
 
 /**
  * @param {Array.<ol.layer.Layer>} selectedLayers The selected layers.

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1208,9 +1208,10 @@ const MainController = function(
         this.ol3dm_.setTree(struct3D.tree);
         this.ol3dm_.load().then(
           () => {
-            appLayerPermalinkManager.initBgLayers_().then(
-              () => this.ol3dm_.init3dTilesFromLocation()
-            );
+            // appLayerPermalinkManager.initBgLayers_().then(
+            //   () => 
+                this.ol3dm_.init3dTilesFromLocation()
+            // );
           }
         );
       }


### PR DESCRIPTION
This PR should allow opening permalinks in 3D mode correctly (eg. https://migration.geoportail.lu/theme/main?version=3&X=662398&Y=6360606&zoom=18&lang=fr&rotation=0&bgLayer=streets_jpeg&crosshair=false&layers=&opacities=&time=&streets_jpeg=&serial=&3d_layers=ACT2022_BD_L_BATI3D_LOD2%2CVDL2022_LOD2_IMPORT_old%2CBridges_LOD2%2CACT2019_LiDAR_Bridges_LOD1%2CACT2019_LiDAR_Vegetation&3d_enabled=true&3d_lon=5.95042&3d_lat=49.49531&3d_elevation=696&3d_heading=360.000&3d_pitch=-39.984).

For the fix, the `appLayerPermalinkManager.initBgLayers_()` which returned an empty Promise is not called anymore. The included logic of the function already does not seem to be used anymore and was thus not migrated further into v4. The part regarding the `tourisme` theme could not be reproduced on production, and opacity logic only seems relevant for v2.