### PR TITLE
GSLUX-715: Restrict zoom in offline mode

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/Downloader.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/Downloader.js
@@ -107,6 +107,9 @@ const Downloader = class {
     const persistentLayers = [];
     const queue = [];
     const zooms = [];
+    const backgroundLayerPresent = layersMetadatas.some((layer) => layer.backgroundLayer === true);
+    const thematicLayerPresent = layersMetadatas.some((layer) => layer.backgroundLayer === false);
+    const onlyBackgroundLayerPresent = backgroundLayerPresent && !thematicLayerPresent;
     for (const layerItem of layersMetadatas) {
       if (layerItem.layerType === 'tile') {
         const tiles = [];
@@ -120,8 +123,8 @@ const Downloader = class {
         key: this.configuration_.getLayerKey(layerItem),
       });
 
-      // do not include zooms for background layers to restrict offline mode to the thematic layers zoom levels
-      if (layerItem.backgroundLayer === false) {
+      // if thematic layers present, do not include zooms for background layers to restrict offline mode to the thematic layers zoom levels
+      if (onlyBackgroundLayerPresent || layerItem.backgroundLayer === false) {
         layerItem.extentByZoom.forEach((obj) => {
           const zoom = obj.zoom;
           if (zooms.indexOf(zoom) < 0) {

--- a/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/Downloader.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/ngeo/src/offline/Downloader.js
@@ -120,12 +120,15 @@ const Downloader = class {
         key: this.configuration_.getLayerKey(layerItem),
       });
 
-      layerItem.extentByZoom.forEach((obj) => {
-        const zoom = obj.zoom;
-        if (zooms.indexOf(zoom) < 0) {
-          zooms.push(zoom);
-        }
-      });
+      // do not include zooms for background layers to restrict offline mode to the thematic layers zoom levels
+      if (layerItem.backgroundLayer === false) {
+        layerItem.extentByZoom.forEach((obj) => {
+          const zoom = obj.zoom;
+          if (zooms.indexOf(zoom) < 0) {
+            zooms.push(zoom);
+          }
+        });
+      }
     }
 
     /**


### PR DESCRIPTION
This PR restricts offline mode to the thematic layers zoom levels if a thematic layer is present. In this case it does not include zooms for background layers on save in order to take the first and last zoom levels from the thematic layers when restoring via getItem('offline_content').

This seems a little like a workaround since this condition is not necessary on prod. 

That being said, the missing zoom restrictions actually also seem to be present on prod when using a thematic layer with the orthophotos as a baselayer.