### PR TITLE
GSLUX-718: Fix i18n (bis)

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -18,10 +18,14 @@ import 'angular';
 import 'angular-gettext';
 import 'angular-dynamic-locale';
 
-import { 
-  app,
+import useLuxLib, {
+  createApp,
+  h,
+  backend,
+  App,
+  defineCustomElement,
+  getCurrentInstance,
   i18next as Luxi18next,
-  createElementInstance,
   storeToRefs,
   watch,
   AlertNotifications,
@@ -48,8 +52,39 @@ import {
   statePersistorMyMapService,
   statePersistorStyleService,
   themeSelectorService,
-  SliderComparator
+  SliderComparator,
+  backend as Luxi18backend,
+  I18NextVue,
+  createPinia,
+  VueDOMPurifyHTML
 } from "luxembourg-geoportail/bundle/lux.dist.js";
+
+const i18nextConfig = {
+  ns: 'client',
+  nonExplicitWhitelist: true,
+  returnEmptyString: false,
+  fallbackLng: 'en',
+  debug: false,
+  backend: {
+    loadPath: async (lng, ns) => {
+      if (ns === 'app') {
+        return '/static-ngeo/locales/{{app}}.{{lng}}.json'
+      }
+
+      const response = await fetch("/dynamic.json");
+      const dynamicUrls = await response.json();
+
+      return dynamicUrls.constants.langUrls[lng]
+    },
+    parse: function(data, lng, ns) {
+      return JSON.parse(data)[lng]
+    }
+  },
+  nsSeparator: '|', // ! force separator to '|' instead of ':' because some i18n keys have ':' (otherwise, i18next doesn't find the key)
+};
+
+const luxLib = useLuxLib({ i18nextConfig });
+const { app, createElementInstance } =  luxLib;
 
 // Important! keep order
 statePersistorMyMapService.bootstrap()

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#9f275d8e9caf52241b2b5f76bffc303e7fb80dc6",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail.git#942bd52874cf2144202ecde81e4a7ee64f0c8dd1",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-718

### Description

- extract i18n from v4 into app._LANG_.json (combination of app._LANG.json from prod + i18n specific to v4, eg. aria labels, non existing v3 i18n)
- update legacy client._LANG_.json with prod version (removed specific v4 i18n from this file)
- passing i18next backend config (v3 url to cached fr.json) to lib lux


This PR needs https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/126