### PR TITLE
GSLUX-726: Highlight cadastral parcel on search

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
@@ -96,6 +96,8 @@ const exports = function($scope, $window, $compile,
   this.layerLookup_ = {
     'Adresse': ['addresses'],
     'Parcelle': ['parcels', 'parcels_labels'],
+    'Parcelle_go': ['parcels_go', 'parcels_labels_go'],
+    'Parcelle_prof': ['parcels_prof', 'parcels_labels'],
     'lieu_dit': ['toponymes'],
     'FLIK': ['asta_flik_parcels'],
     'FLIK_Provisoire': ['asta_flik_parcels_provisoire'],
@@ -940,8 +942,13 @@ exports.selected_ =
               if (arrayIncludes(this.showGeom_, feature.get('layer_name'))) {
                 features.push(feature);
               }
+              var cur_suggestion_layer = suggestion.get('layer_name');
+              if (cur_suggestion_layer === 'Parcelle' &&
+                  arrayIncludes(['go', 'prof'], this.appTheme_.getCurrentTheme())) {
+                    cur_suggestion_layer = cur_suggestion_layer + '_' + this.appTheme_.getCurrentTheme();
+                  }
               var layers = /** @type {Array<string>} */
-              (this.layerLookup_[suggestion.get('layer_name')] || []);
+              (this.layerLookup_[cur_suggestion_layer] || []);
               layers.forEach(function(layer) {
                 // this.addLayerToMap_(/** @type {string} */ (layer));
                 // ------------

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
@@ -33,7 +33,7 @@ import Fuse from 'fuse.js';
 import { matchCoordinate } from '../CoordinateMatch'
 import olcsCore from 'olcs/core.js';
 
-import { useLayers, useThemes, useThemeStore, useBackgroundLayer, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.js";
+import { useLayers, useThemes, useThemeStore, useMapStore, useBackgroundLayer, storeToRefs, watch } from "luxembourg-geoportail/bundle/lux.dist.js";
 
 
 /**
@@ -955,7 +955,9 @@ exports.selected_ =
                 // v4 migration, use addLayerToStore_ instead
                 // ------------
                 const layerToAdd = useThemes().findByName(layer, this.themeStore_.theme);
-                this.addLayerToStore_(layerToAdd.id);
+                if (!useMapStore().hasLayer(layerToAdd.id)) {
+                  this.addLayerToStore_(layerToAdd.id);
+                }
               }.bind(this));
             } else {
               feature.setGeometry(

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/search/SearchController.js
@@ -957,9 +957,11 @@ exports.selected_ =
               features.push(feature);
             }
           }
-          for (var i = 0; i < features.length; ++i) {
-            this.featureOverlay.addFeature(features[i]);
-          }
+          setTimeout(() => {
+            for (var i = 0; i < features.length; ++i) {
+              this.featureOverlay.addFeature(features[i]);
+            }
+          }, 0)
         }
       // } else if (dataset === 'layers') { //Layer
       //   this.addLayerToMap_(/** @type {Object} */ (suggestion));


### PR DESCRIPTION
This PR should fix:
- highlighting a cadastral parcel selected in the search
- adding layers from corresponding theme (cherry-picked from master and not tested locally)
- not removing cadastral parcel layer on a new cadastral search if one is already active

PR can be tested locally with tweak plugin for example using a `http://localhost:8080/fulltextsearch?query=8&limit=8` response from prod that includes a parcel.