### PR TITLE
fix correct update of permalink

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -1198,6 +1198,7 @@ const MainController = function(
               config = JSON.parse(style)['serial'];
             }
             this.ngeoLocation_.updateParams({
+              'bgLayer': label,
               'serial': config,
               'serialLayer': label
             });


### PR DESCRIPTION
I believe this bug is related to the problem of bgLayer missing sometimes
This fix resolves a conflict in permalink update between v3 and v4 leading to js errors and incorrect styling.
Once trapped in a pad permalink / localstorage combination, bad things happen.

Unfortunately, it is again impossible to reproduce the reported bug, so we should merge the fix to check if evrything is going fine in the deployed app