### PR TITLE
GSLUX-639: Integrate style panel

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/main.html.ejs
@@ -286,13 +286,7 @@
         </div>
         <!-- Vector editor -->
         <div id="vectoreditor" ng-class="mainCtrl.vectorEditorOpen ? 'show' : 'hide'">
-          <h2 translate>Vector tiles editor</h2>
-          <button class="close-panel" ng-click="mainCtrl.closeSidebar()">
-            ✕
-          </button>
-          <div class="container-fluid tab-content">
-            <style-selector/>
-          </div>
+          <style-panel/>
         </div>
     </div>
     <div class="map-wrapper">

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/download/GSLUX-749-auth-finalize_CI_dac4327/luxembourg-geoportail-lib-0.0.0-dev.tgz",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/download/GSLUX-639-style-panel-export_CI_c3cc294/luxembourg-geoportail-lib-0.0.0-dev.tgz",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
PR integrates the `style-panel` replacing the `style-selector`.

To-do

- [x] Update `package.json` to release including https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/166

Note that closing the `style-panel` in v3 still closes the sidebar as this is handled by the angular template. The evolution of keeping the sidebar open is only available in v4 app.

Note also that the "Vector tiles editor" translation is missing locally, but present on migration.