### PR TITLE
GSLUX-767: Use new v4 profile component in routing

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/apps/MainController.js
@@ -32,6 +32,8 @@ import useLuxLib, {
   AuthForm,
   ProfileDraw,
   ProfileMeasures,
+  ProfileRouting,
+  ProfileInfos,
   LayerPanel,
   LegendsPanel,
   MapContainer,
@@ -50,6 +52,7 @@ import useLuxLib, {
   useOfflineLayers,
   useStyleStore,
   useThemeStore,
+  useProfileRoutingv3Store,
   layerMetadataService,
   statePersistorAppService,
   statePersistorBgLayerService,
@@ -136,6 +139,8 @@ customElements.define('alert-notifications', AlertNotificationsElement)
 customElements.define('auth-form', createElementInstance(AuthForm, app))
 customElements.define('profile-draw', createElementInstance(ProfileDraw, app))
 customElements.define('profile-measures', createElementInstance(ProfileMeasures, app))
+customElements.define('profile-routing', createElementInstance(ProfileRouting, app))
+customElements.define('profile-infos', createElementInstance(ProfileInfos, app))
 
 import i18next from 'i18next';
 
@@ -1441,6 +1446,16 @@ const MainController = function(
         this['layersOpen'] = false;
       }
       legendsOpen.value = newVal;
+    });
+
+    // V4 for profile in routing
+    $scope.$watch(() => {
+      return this['routingOpen'];
+    }, newVal => {
+      const profileRoutingStore = useProfileRoutingv3Store();
+      const { activePositioning_v3 } = storeToRefs(profileRoutingStore);
+
+      activePositioning_v3.value = newVal;
     });
 
     // listen to legendsOpen to open/close Legends panel in main.html

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/routing/routing.html
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/routing/routing.html
@@ -67,8 +67,16 @@
               </div>
           </div>
           <div class="route-graphic-container route-info-container" ng-if="ctrl.profileData.length > 0">
-              <h3 class="route-info-title" translate>Dénivelé lors de votre trajet</h3>
-              <app-profile app-profile-data="ctrl.profileData" app-profile-interaction="ctrl.showProfile" app-profile-map="::ctrl.map">
+              <h3 class="route-info-title" style="margin-bottom: 10px;" translate>Dénivelé lors de votre trajet</h3>
+
+              <!-- v4 Elevation Profile component -->
+                <div style="display: inline;">
+                    <div style="width: 283px; height: auto;">
+                        <profile-routing />
+                    </div>
+                </div>
+
+              <!-- <app-profile app-profile-data="ctrl.profileData" app-profile-interaction="ctrl.showProfile" app-profile-map="::ctrl.map"> -->
           </div>
 
           <div class="route-details route-info-container">

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/download/GSLUX-686-profil-component_CI_f55a666/luxembourg-geoportail-lib-0.0.0-dev.tgz",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/download/GSLUX-767-profile-routing-v3_CI_4cf9e8b/luxembourg-geoportail-lib-0.0.0-dev.tgz",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSLUX-767

Use new v4 Profile Component in Routing.

PR to be used: https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/176

NB. Routing is not available  in dev, use chrome extension (eg. Tweak) to modify api responses. Also, units in dev does not correspond to production, you may again tweak de api response to get the real values (did not find a way to configure units in v3.