### PR TITLE
GSLUX-770: Fix draw and layers in permalink v3

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/draw/DrawnFeatures.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/draw/DrawnFeatures.js
@@ -14,6 +14,8 @@ import olGeomGeometryType from 'ol/geom/GeometryType.js';
 import {createEmpty, extend} from 'ol/extent.js';
 import olCollection from 'ol/Collection.js';
 
+import { storageHelper } from "luxembourg-geoportail/bundle/lux.dist.js";
+
 /**
  * @constructor
  * @param {ngeo.statemanager.Location} ngeoLocation Location service.
@@ -208,13 +210,24 @@ exports.prototype.encodeFeaturesInUrl_ = function(features) {
   var featuresToEncode = features.filter(function(feature) {
     return !feature.get('__map_id__');
   });
+
   if (featuresToEncode.length > 0) {
-    this.ngeoLocation_.updateParams({
-      'features': this.fhFormat_.writeFeatures(featuresToEncode)
-    });
+    // this.ngeoLocation_.updateParams({
+    //   'features': this.fhFormat_.writeFeatures(featuresToEncode)
+    // });
+
+    // v4
+    storageHelper.setValue(
+      'features',
+      featuresToEncode,
+      (feats) => this.fhFormat_.writeFeatures(feats)
+    )
   } else {
-    this.ngeoLocation_.deleteParam('features');
-  }
+    // this.ngeoLocation_.deleteParam('features');
+
+    // v4
+    storageHelper.removeItem('features')
+  }  
 };
 
 

--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/draw/FeatureHash.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/draw/FeatureHash.js
@@ -382,9 +382,9 @@ class FeatureHash extends olFormatTextFeature {
         if (encodedProperties.length !== 0) {
           encodedProperties.push('\'');
         }
-        var encoded = encodeURIComponent(
+        var encoded = /*encodeURIComponent(*/
             key.replace(/[()'*]/g, '_') + '*' +
-            value.toString().replace(/[()'*]/g, '_'));
+            value.toString().replace(/[()'*]/g, '_')/*)*/; // v4 encode is done in storage helper
         encodedProperties.push(encoded);
       }
     };
@@ -593,7 +593,7 @@ function encodeStylePoint_(imageStyle, encodedStyles) {
    if (encodedStyles.length > 0) {
      encodedStyles.push('\'');
    }
-   encodedStyles.push(encodeURIComponent('pointRadius*' + radius));
+   encodedStyles.push(/*encodeURIComponent(*/'pointRadius*' + radius)/*)*/; // v4 encode done in storage helper
    var fillStyle = imageStyle.getFill();
    if (fillStyle !== null) {
      encodeStyleFill_(fillStyle, encodedStyles);
@@ -644,8 +644,8 @@ function encodeStyleFill_(fillStyle, encodedStyles, opt_propertyName) {
    if (encodedStyles.length > 0) {
      encodedStyles.push('\'');
    }
-   encodedStyles.push(
-       encodeURIComponent(propertyName + '*' + fillColorHex));
+   encodedStyles.push(/*
+       encodeURIComponent(*/propertyName + '*' + fillColorHex/*)*/);
  }
 };
 
@@ -667,14 +667,14 @@ function encodeStyleStroke_(strokeStyle, encodedStyles) {
    if (encodedStyles.length > 0) {
      encodedStyles.push('\'');
    }
-   encodedStyles.push(encodeURIComponent('strokeColor*' + strokeColorHex));
+   encodedStyles.push(/*encodeURIComponent(*/'strokeColor*' + strokeColorHex/*)*/);
  }
  var strokeWidth = strokeStyle.getWidth();
  if (strokeWidth !== undefined) {
    if (encodedStyles.length > 0) {
      encodedStyles.push('\'');
    }
-   encodedStyles.push(encodeURIComponent('strokeWidth*' + strokeWidth));
+   encodedStyles.push(/*encodeURIComponent(*/'strokeWidth*' + strokeWidth/*)*/);
  }
 };
 
@@ -694,7 +694,7 @@ function encodeStyleText_(textStyle, encodedStyles) {
      if (encodedStyles.length > 0) {
        encodedStyles.push('\'');
      }
-     encodedStyles.push(encodeURIComponent('fontSize*' + font[1]));
+     encodedStyles.push(/*encodeURIComponent(*/'fontSize*' + font[1]/*)*/);
    }
  }
  var fillStyle = textStyle.getFill();

--- a/geoportal/package.json
+++ b/geoportal/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Geoportail-Luxembourg/geoportailv3/issues"
   },
   "devDependencies": {
-    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/download/GSLUX-769-fix-profile-measures_CI_20f3c10/luxembourg-geoportail-lib-0.0.0-dev.tgz",
+    "luxembourg-geoportail": "https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/releases/download/GSLUX-770-fix-draw-permalink_CI_5d4a990/luxembourg-geoportail-lib-0.0.0-dev.tgz",
     "@babel/core": "7.16.0",
     "@babel/plugin-proposal-class-properties": "7.16.0",
     "@babel/plugin-proposal-decorators": "7.16.0",


### PR DESCRIPTION
<!-- Title must be: GSLUX-XXX: Description of changes -->

### JIRA issue

https://jira.camptocamp.com/browse/GSLUX-770

### Description

Use storage helper from v4 to update correctly features in url without removing newly added layers.

- [x]  Update package.json before merging https://github.com/Geoportail-Luxembourg/luxembourg-geoportail/pull/179