### PR TITLE
Gslux 773 ol controls error

### DIFF
--- a/geoportal/geoportailv3_geoportal/static-ngeo/js/query/QueryController.js
+++ b/geoportal/geoportailv3_geoportal/static-ngeo/js/query/QueryController.js
@@ -428,6 +428,10 @@ exports.prototype.$onInit = function() {
   }, this);
 
   listen(this.map_, 'pointerup', function(evt) {
+    // skip click handler on ol controls since they are handled directly in V4
+    if (evt.originalEvent.target.closest('.ol-control')) {
+      return
+    }
     this.timeout_.cancel(this.holdPromise);
     var tempTime = new Date().getTime();
     if ((tempTime - this.pointerUpTime_) <= 499) {


### PR DESCRIPTION
feature selection triggered a console error when clicking on OL controls.

=> Disable V3 handling for clicks on OL control buttons.